### PR TITLE
Correct identification of easystats as R package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+docs/* linguist-documentation
+paper/* linguist-documentation


### PR DESCRIPTION
:wave: Hi @strengejacke,
I've noticed that `easystats` is tagged as mostly HTML by [GitHub's linguist](https://github.com/github/linguist), I've followed the [overriding instructions](https://github.com/github/linguist#overrides) which should let the repo be tagged as pure R.