### PR TITLE
fixed issue #208

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Fixed issue that occured since R 4.0.0 in `find_weights()` when function call had no `weights`-argument.
 * Fixed issue in `get_data()` for models with `cbind()`-response variables and matrix-like variables in the model frame (e.g. when using `poly()`).
 * Fixed issues with `PROreg::BBmm()`, due to changes in latest package update.
+* Fixed issue in `find_formula` for mixed models, it didn't recognise fixed effects placed between random effects.
 
 # insight 0.8.5
 

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -165,10 +165,10 @@
       no_bars <- stats::drop.terms(f_terms, pos_bar, keep.response = TRUE)
       stats::update(f_terms, no_bars)
     } else {
-      .trim(gsub("\\+(\\s)*\\((.*)\\)", "", f_string))
+      .trim(gsub("\\+(\\s)*\\((.*?)\\)", "", f_string))
     }
   } else {
-    .trim(gsub("\\+(\\s)*\\((.*)\\)", "", f_string))
+    .trim(gsub("\\+(\\s)*\\((.*?)\\)", "", f_string))
   }
 }
 


### PR DESCRIPTION
fix issue #208 

Previously:  
```
> tfit <- glmmTMB(am ~ disp:wt + (1|gear) + wt + (1|carb), data = mtcars)
> find_formula(tfit)
$conditional
am ~ disp:wt
<environment: 0x55ab245aaab8>

$random
$random[[1]]
~1 | gear
<environment: 0x55ab24794290>

$random[[2]]
~1 | carb
<environment: 0x55ab248b0f20>
```
Now should be (I just checked `.get_fixed_effects` on `$conditional`)
```
> tfit <- glmmTMB(am ~ disp:wt + (1|gear) + wt + (1|carb), data = mtcars)
> find_formula(tfit)
$conditional
am ~ disp:wt  + wt
<environment: 0x55ab245aaab8>

$random
$random[[1]]
~1 | gear
<environment: 0x55ab24794290>

$random[[2]]
~1 | carb
<environment: 0x55ab248b0f20>
```
These small corrections may have to be performed also inside first `if (length(f) > 2 && starts_with_parantheses && has_bar)`