### PR TITLE
minor change to follow broom convention for `htest`

### DIFF
--- a/R/standardize_names.R
+++ b/R/standardize_names.R
@@ -104,6 +104,7 @@ standardize_names.parameters_distribution <- function(data, style = c("easystats
     cn[cn == "Effects"] <- "effect"
     cn[cn == "Response"] <- "response"
     cn[cn == "CI"] <- "ci.width"
+    cn[cn == "df"] <- "parameter"
     cn[cn == "df_error"] <- "df.error"
     cn[cn == "df_residual"] <- "df.residual"
     cn[cn == "n_Obs"] <- "n.obs"

--- a/tests/testthat/test-standardize_names.R
+++ b/tests/testthat/test-standardize_names.R
@@ -25,7 +25,7 @@ if (require("testthat") &&
 
     expect_equal(
       names(standardize_names(y, style = "broom")),
-      c("term", "sumsq", "df", "meansq", "statistic", "p.value")
+      c("term", "sumsq", "parameter", "meansq", "statistic", "p.value")
     )
   })
 
@@ -38,7 +38,7 @@ if (require("testthat") &&
     names(standardize_names(z, style = "broom")),
     c(
       "parameter1", "parameter2", "mean.parameter1", "mean.parameter2",
-      "estimate", "statistic", "df", "p.value", "conf.low", "conf.high",
+      "estimate", "statistic", "parameter", "p.value", "conf.low", "conf.high",
       "method"
     )
   )
@@ -48,6 +48,6 @@ if (require("testthat") &&
 
   expect_equal(
     names(standardize_names(t, style = "broom")),
-    c("parameter1", "parameter2", "statistic", "df", "p.value", "method")
+    c("parameter1", "parameter2", "statistic", "parameter", "p.value", "method")
   )
 }


### PR DESCRIPTION
``` r
broom::tidy(t.test(extra ~ group, data = sleep))
#> # A tibble: 1 x 10
#>   estimate estimate1 estimate2 statistic p.value parameter conf.low conf.high
#>      <dbl>     <dbl>     <dbl>     <dbl>   <dbl>     <dbl>    <dbl>     <dbl>
#> 1    -1.58      0.75      2.33     -1.86  0.0794      17.8    -3.37     0.205
#> # ... with 2 more variables: method <chr>, alternative <chr>

heads <- rbinom(1, size = 100, prob = .5)
broom::tidy(prop.test(heads, 100))
#> # A tibble: 1 x 8
#>   estimate statistic p.value parameter conf.low conf.high method     alternative
#>      <dbl>     <dbl>   <dbl>     <int>    <dbl>     <dbl> <chr>      <chr>      
#> 1     0.59      2.89  0.0891         1    0.487     0.686 1-sample ~ two.sided
```

Currently, using `parameters` + `insight::standardize_names` leaves the `df` column as `df` instead of calling it `parameter` when `broom`-style is chosen.

This PR fixes that.
