### PR TITLE
changing convention; cf. https://github.com/tidymodels/broom/issues/984

### DIFF
--- a/R/standardize_names.R
+++ b/R/standardize_names.R
@@ -121,7 +121,7 @@ standardize_names.parameters_distribution <- standardize_names.parameters_model
   cn[cn == "statistic"] <- "Statistic"
   cn[cn == "conf.low"] <- "CI_low"
   cn[cn == "conf.high"] <- "CI_high"
-  cn[cn == "ci.width"] <- "CI"
+  cn[cn == "conf.level"] <- "CI"
   cn[cn == "n.obs"] <- "n_Obs"
   # anova
   cn[cn == "sumsq"] <- "Sum_Squares"
@@ -155,7 +155,7 @@ standardize_names.parameters_distribution <- standardize_names.parameters_model
   cn[cn == "Component"] <- "component"
   cn[cn == "Effects"] <- "effect"
   cn[cn == "Response"] <- "response"
-  cn[cn == "CI"] <- "ci.width"
+  cn[cn == "CI"] <- "conf.level"
   cn[cn == "df_error"] <- "df.error"
   cn[cn == "df_residual"] <- "df.residual"
   cn[cn == "n_Obs"] <- "n.obs"

--- a/tests/testthat/test-standardize_names.R
+++ b/tests/testthat/test-standardize_names.R
@@ -15,7 +15,7 @@ if (require("testthat") &&
       expect_equal(
         names(standardize_names(x, style = "broom")),
         c(
-          "term", "estimate", "std.error", "ci.width", "conf.low", "conf.high",
+          "term", "estimate", "std.error", "conf.level", "conf.low", "conf.high",
           "statistic", "df.error", "p.value"
         )
       )
@@ -42,7 +42,7 @@ if (require("testthat") &&
       names(standardize_names(z, style = "broom")),
       c(
         "parameter1", "parameter2", "mean.parameter1", "mean.parameter2", "estimate",
-        "ci.width", "conf.low", "conf.high", "statistic", "df.error", "p.value", "method"
+        "conf.level", "conf.low", "conf.high", "statistic", "df.error", "p.value", "method"
       )
     )
   }


### PR DESCRIPTION
As I had suspected, `broom` doesn't actually have any convention about the CI column.

So I would prefer to default to `conf.level`, which is more in line with `tidymodels`'s argument naming.