### PR TITLE
algebra trick for much faster SEs in `get_predicted`

### DIFF
--- a/R/get_predicted_ci.R
+++ b/R/get_predicted_ci.R
@@ -291,18 +291,19 @@ get_predicted_se <- function(x,
   mm <- .get_predicted_ci_modelmatrix(x, data = data, vcovmat = vcovmat)
 
   # compute vcov for predictions
-  var_matrix <- mm %*% vcovmat %*% t(mm)
+  # Next line equivalent to: diag(M V M')
+  var_diag <- colSums(t(mm %*% vcovmat) * t(mm))
 
   # add sigma to standard errors, i.e. confidence or prediction intervals
   ci_type <- match.arg(ci_type, c("confidence", "prediction"))
   if (ci_type == "prediction") {
     if (is_mixed_model(x)) {
-      se <- sqrt(diag(var_matrix) + get_variance_residual(x))
+      se <- sqrt(var_diag + get_variance_residual(x))
     } else {
-      se <- sqrt(diag(var_matrix) + get_sigma(x)^2)
+      se <- sqrt(var_diag + get_sigma(x)^2)
     }
   } else {
-    se <- sqrt(diag(var_matrix))
+    se <- sqrt(var_diag)
   }
 
   se

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -381,3 +381,12 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
     expect_equal(dim(x), c(5, 3))
   })
 }
+
+
+
+test_that("check SE against barebones `predict`", {
+  mod <- lm(mpg ~ hp + factor(cyl), mtcars)
+  known <- predict(mod, se.fit = TRUE)$se.fit
+  unknown <- as.data.frame(get_predicted(mod))$SE
+  expect_equal(known, unknown)
+})


### PR DESCRIPTION
Today I was having trouble with `get_predicted`: it was taking a ton of time to produce estimates for a model with about 50K observations. So I decided to do a bit of profiling. It turns out that the vast majority of the time was spent on the “sandwich” multiplication.

In this PR, I introduce a simple matrix algebra trick for the sandwich computation, which yields roughly 1000x speedup in computation and 1000x reduction in memory load.

To begin, let’s create a variance-covariance matrix and a large model matrix by stacking `mtcars` multiple times:

``` r
library(bench)

mod <- lm(mpg ~ factor(cyl) + hp + drat, mtcars)
mtbig <- do.call("rbind", lapply(1:500, \(x) mtcars))
mm <- model.matrix(mod, data = mtbig)
vcovmat <- vcov(mod)
```

Before running the benchmark, let’s convince ourselves that the two strategies yield the same results at 10 digits tolerance:

``` r
old <- sqrt(diag(mm %*% vcovmat %*% t(mm)))
new <- sqrt(colSums(t(mm %*% vcovmat) * t(mm)))

identical(round(old, 10), round(new, 10))
# [1] TRUE
```

Run benchmark:

``` r
bench::mark(
    sqrt(diag(mm %*% vcovmat %*% t(mm))),
    sqrt(colSums(t(mm %*% vcovmat) * t(mm))))

#   expression                                    min   median `itr/sec` mem_alloc
#   <bch:expr>                               <bch:tm> <bch:tm>     <dbl> <bch:byt>
# 1 sqrt(diag(mm %*% vcovmat %*% t(mm)))        1.36s    1.36s     0.735    1.91GB
# 2 sqrt(colSums(t(mm %*% vcovmat) * t(mm))) 577.71µs   1.44ms   694.       1.95MB
```

After installing my branch, I tried `get_predicted` again on my problematic dataset, and the result came up almost instantaneously, whereas I had to wait a couple minutes before.