### PR TITLE
`requiet` makes `testthat` log readable

### DIFF
--- a/tests/testthat/helper-requiet.R
+++ b/tests/testthat/helper-requiet.R
@@ -1,0 +1,5 @@
+requiet <- function(package) {
+  suppressPackageStartupMessages(
+    require(package, warn.conflicts = FALSE, character.only = TRUE)
+  )
+}

--- a/tests/testthat/test-BayesFactorBF.R
+++ b/tests/testthat/test-BayesFactorBF.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("insight") && require("stats") && require("BayesFactor")) {
+if (.runThisTest && requiet("testthat") && requiet("insight") && requiet("stats") && requiet("BayesFactor")) {
   x <- correlationBF(y = iris$Sepal.Length, x = iris$Sepal.Width)
   test_that("get_data", {
     expect_true(is.data.frame(get_data(x)))

--- a/tests/testthat/test-FE-formula.R
+++ b/tests/testthat/test-FE-formula.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   gfe <- insight:::.get_fixed_effects
 
   test_that(".get_fixed_effects", {

--- a/tests/testthat/test-GLMMadaptive.R
+++ b/tests/testthat/test-GLMMadaptive.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") && require("insight") && require("GLMMadaptive") && require("lme4")) {
+  if (requiet("testthat") && requiet("insight") && requiet("GLMMadaptive") && requiet("lme4")) {
     m <- download_model("GLMMadaptive_zi_2")
     m2 <- download_model("GLMMadaptive_zi_1")
 

--- a/tests/testthat/test-Gam2.R
+++ b/tests/testthat/test-Gam2.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("insight") &&
-  require("gam")) {
+  requiet("testthat") &&
+  requiet("insight") &&
+  requiet("gam")) {
   data(kyphosis)
   m1 <- gam::gam(
     Kyphosis ~ s(Age, 4) + Number,

--- a/tests/testthat/test-LORgee.R
+++ b/tests/testthat/test-LORgee.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("multgee")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("multgee")) {
   data(arthritis)
   m1 <- ordLORgee(
     y ~ factor(time) + factor(trt) + factor(baseline),

--- a/tests/testthat/test-MCMCglmm.R
+++ b/tests/testthat/test-MCMCglmm.R
@@ -13,9 +13,9 @@ osx <- tryCatch(
 )
 
 
-if (!osx && require("testthat") &&
-  require("insight") &&
-  require("MCMCglmm")) {
+if (!osx && requiet("testthat") &&
+  requiet("insight") &&
+  requiet("MCMCglmm")) {
   data(PlodiaPO)
   m1 <- MCMCglmm(
     PO ~ plate,

--- a/tests/testthat/test-afex_aov.R
+++ b/tests/testthat/test-afex_aov.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("afex")) {
+if (requiet("testthat") && requiet("insight") && requiet("afex")) {
   data(obk.long, package = "afex")
 
   obk.long$treatment <- as.character(obk.long$treatment)

--- a/tests/testthat/test-all_models_equal.R
+++ b/tests/testthat/test-all_models_equal.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data(mtcars)
   data(sleepstudy)
 

--- a/tests/testthat/test-aovlist.R
+++ b/tests/testthat/test-aovlist.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("stats")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("stats")) {
   data(npk)
   m1 <- aov(yield ~ N * P * K + Error(block), data = npk)
   m2 <- aov(yield ~ N * P * K, data = npk)

--- a/tests/testthat/test-backticks.R
+++ b/tests/testthat/test-backticks.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   data(iris)
   iris$`a m` <- iris$Species
   iris$`Sepal Width` <- iris$Sepal.Width

--- a/tests/testthat/test-betabin.R
+++ b/tests/testthat/test-betabin.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("aod")) {
+if (requiet("testthat") && requiet("insight") && requiet("aod")) {
   data(dja)
   m1 <- suppressWarnings(betabin(cbind(y, n - y) ~ group * trisk, ~village, data = dja))
 

--- a/tests/testthat/test-betareg.R
+++ b/tests/testthat/test-betareg.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("betareg")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("betareg")) {
   data("GasolineYield")
   data("FoodExpenditure")
 

--- a/tests/testthat/test-bigglm.R
+++ b/tests/testthat/test-bigglm.R
@@ -1,8 +1,8 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") &&
-    require("insight") && require("glmmTMB") && require("biglm")) {
+  if (requiet("testthat") &&
+    requiet("insight") && requiet("glmmTMB") && requiet("biglm")) {
     data(Salamanders)
     Salamanders$cover <- abs(Salamanders$cover)
 

--- a/tests/testthat/test-blmer.R
+++ b/tests/testthat/test-blmer.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("blme")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("blme")) {
   data(sleepstudy)
   set.seed(123)
   sleepstudy$mygrp <- sample(1:5, size = 180, replace = TRUE)

--- a/tests/testthat/test-brms.R
+++ b/tests/testthat/test-brms.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (suppressWarnings(require("testthat") &&
-    require("insight") &&
-    require("brms"))) {
+  if (suppressWarnings(requiet("testthat") &&
+    requiet("insight") &&
+    requiet("brms"))) {
 
     # Model fitting -----------------------------------------------------------
 

--- a/tests/testthat/test-censReg.R
+++ b/tests/testthat/test-censReg.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("censReg") &&
-  require("AER")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("censReg") &&
+  requiet("AER")) {
   data("Affairs", package = "AER")
   m1 <-
     censReg(affairs ~ age + yearsmarried + religiousness + occupation + rating,

--- a/tests/testthat/test-cgam.R
+++ b/tests/testthat/test-cgam.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("cgam")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("cgam")) {
   data(cubic, package = "cgam")
   m <- cgam(y ~ incr.conv(x), data = cubic)
 

--- a/tests/testthat/test-check_if_installed.R
+++ b/tests/testthat/test-check_if_installed.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   test_that("export_table", {
     # mimic package name if cat were to walk on a keyboard
     expect_error(check_if_installed("xklfueofi8eur3rnfalfb"))

--- a/tests/testthat/test-clean_names.R
+++ b/tests/testthat/test-clean_names.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   test_that("clean_names", {
     expect_equal(clean_names(""), "")
     expect_equal(clean_names("as.factor(test)"), "test")

--- a/tests/testthat/test-clm.R
+++ b/tests/testthat/test-clm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("ordinal")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("ordinal")) {
   data(wine, package = "ordinal")
   m1 <- clm(rating ~ temp * contact, data = wine)
 

--- a/tests/testthat/test-clm2.R
+++ b/tests/testthat/test-clm2.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("ordinal") &&
-  require("MASS")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("ordinal") &&
+  requiet("MASS")) {
   data(housing, package = "MASS")
   m1 <- clm2(Sat ~ Infl + Type + Cont, weights = Freq, data = housing)
 

--- a/tests/testthat/test-clmm.R
+++ b/tests/testthat/test-clmm.R
@@ -12,9 +12,9 @@ osx <- tryCatch(
   }
 )
 
-if (require("testthat") &&
-  require("insight") &&
-  require("ordinal")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("ordinal")) {
   data(wine, package = "ordinal")
   data(soup)
 

--- a/tests/testthat/test-coxme.R
+++ b/tests/testthat/test-coxme.R
@@ -1,10 +1,10 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("survival") &&
-  require("lme4") &&
-  require("nlme") &&
-  require("bdsmatrix") &&
-  require("coxme")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("survival") &&
+  requiet("lme4") &&
+  requiet("nlme") &&
+  requiet("bdsmatrix") &&
+  requiet("coxme")) {
   set.seed(1234)
   lung$inst2 <- sample(1:10, size = nrow(lung), replace = TRUE)
   lung <- subset(lung, subset = ph.ecog %in% 0:2)

--- a/tests/testthat/test-coxph.R
+++ b/tests/testthat/test-coxph.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("survival")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("survival")) {
   lung <- subset(lung, subset = ph.ecog %in% 0:2)
   lung$sex <- factor(lung$sex, labels = c("male", "female"))
   lung$ph.ecog <- factor(lung$ph.ecog, labels = c("good", "ok", "limited"))
@@ -103,7 +103,7 @@ if (require("testthat") &&
     expect_identical(find_statistic(m1), "z-statistic")
   })
 
-  if (require("JM")) {
+  if (requiet("JM")) {
     data("aids", package = "JM")
     m <- coxph(Surv(start, stop, event) ~ CD4, data = aids)
     test_that("coxph triple response", {

--- a/tests/testthat/test-cpglmm.R
+++ b/tests/testthat/test-cpglmm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("cplm")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("cplm")) {
   data("FineRoot")
   m1 <- cpglmm(RLD ~ Stock + Spacing + (1 | Plant), data = FineRoot)
 

--- a/tests/testthat/test-crch.R
+++ b/tests/testthat/test-crch.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("crch")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("crch")) {
   data("RainIbk")
   RainIbk$sqrtensmean <- apply(sqrt(RainIbk[, grep("^rainfc", names(RainIbk))]), 1, mean)
   RainIbk$sqrtenssd <- apply(sqrt(RainIbk[, grep("^rainfc", names(RainIbk))]), 1, sd)

--- a/tests/testthat/test-crq.R
+++ b/tests/testthat/test-crq.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("quantreg")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("quantreg")) {
   set.seed(123)
   n <- 200
   x <- rnorm(n)

--- a/tests/testthat/test-data.frame.R
+++ b/tests/testthat/test-data.frame.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   data(iris)
 
   test_that("find_parameters", {

--- a/tests/testthat/test-ellipses_info.R
+++ b/tests/testthat/test-ellipses_info.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   data(iris)
 
   m1 <- lm(Sepal.Length ~ Petal.Width + Species, data = iris)

--- a/tests/testthat/test-emmeans.R
+++ b/tests/testthat/test-emmeans.R
@@ -1,4 +1,4 @@
-if (require(emmeans) && require(insight) && require(testthat)) {
+if (requiet("emmeans") && requiet("insight") && requiet("testthat")) {
   test_that("emmeans", {
     m <- glm(am ~ factor(cyl),
              family = binomial(), data = mtcars)

--- a/tests/testthat/test-epiR.R
+++ b/tests/testthat/test-epiR.R
@@ -12,9 +12,9 @@ osx <- tryCatch(
   }
 )
 
-if (!osx && require("testthat") &&
-  require("insight") &&
-  require("epiR")) {
+if (!osx && requiet("testthat") &&
+  requiet("insight") &&
+  requiet("epiR")) {
   dat <- matrix(c(13, 2163, 5, 3349), nrow = 2, byrow = TRUE)
   rownames(dat) <- c("DF+", "DF-")
   colnames(dat) <- c("FUS+", "FUS-")

--- a/tests/testthat/test-export_table.R
+++ b/tests/testthat/test-export_table.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   d <- data.frame(a = c(1.3, 2, 543), b = c("ab", "cd", "abcde"), stringsAsFactors = FALSE)
 
   test_that("export_table", {

--- a/tests/testthat/test-feis.R
+++ b/tests/testthat/test-feis.R
@@ -12,9 +12,9 @@ osx <- tryCatch(
   }
 )
 
-if (!osx && require("testthat") &&
-  require("insight") &&
-  require("feisr")) {
+if (!osx && requiet("testthat") &&
+  requiet("insight") &&
+  requiet("feisr")) {
   data(mwp)
   m1 <- feis(
     lnw ~ marry + enrol + as.factor(yeargr) | exp + I(exp^2),

--- a/tests/testthat/test-felm.R
+++ b/tests/testthat/test-felm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("lfe")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lfe")) {
   x <- rnorm(1000)
   x2 <- rnorm(length(x))
   id <- factor(sample(20, length(x), replace = TRUE))

--- a/tests/testthat/test-find_formula-data.R
+++ b/tests/testthat/test-find_formula-data.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   data(mtcars)
   d <- mtcars
   m1 <- lm(mtcars$mpg ~ mtcars$hp * mtcars$cyl + poly(mtcars$drat, 2) / mtcars$disp)

--- a/tests/testthat/test-find_predictor_nested_re.R
+++ b/tests/testthat/test-find_predictor_nested_re.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   set.seed(1984)
   dat <- data.frame(
     y = rnorm(1000 * 5, sd = 1 - .20),

--- a/tests/testthat/test-find_random.R
+++ b/tests/testthat/test-find_random.R
@@ -12,7 +12,7 @@ osx <- tryCatch(
   }
 )
 
-if (!osx && require("testthat") && require("insight") && require("mgcv") && require("gamm4") && require("rstanarm")) {
+if (!osx && requiet("testthat") && requiet("insight") && requiet("mgcv") && requiet("gamm4") && requiet("rstanarm")) {
   data <- iris
   data$g <- data$Species
   data$Xr <- data$Species

--- a/tests/testthat/test-find_smooth.R
+++ b/tests/testthat/test-find_smooth.R
@@ -14,7 +14,9 @@ osx <- tryCatch(
 
 if (requiet("testthat") && requiet("insight") && requiet("mgcv") && requiet("gamm4") && requiet("rstanarm") && !osx) {
   set.seed(2) ## simulate some data...
-  dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
+  void <- capture.output(
+    dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
+  )
 
   bt <- mgcv::gam(y ~ te(x0, x1, k = 7) + s(x2) + s(x3),
     data = dat,

--- a/tests/testthat/test-find_smooth.R
+++ b/tests/testthat/test-find_smooth.R
@@ -12,7 +12,7 @@ osx <- tryCatch(
   }
 )
 
-if (require("testthat") && require("insight") && require("mgcv") && require("gamm4") && require("rstanarm") && !osx) {
+if (requiet("testthat") && requiet("insight") && requiet("mgcv") && requiet("gamm4") && requiet("rstanarm") && !osx) {
   set.seed(2) ## simulate some data...
   dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
 

--- a/tests/testthat/test-find_terms.R
+++ b/tests/testthat/test-find_terms.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   test_that("find_terms", {
     m <- lm(Sepal.Length ~ -1 + Petal.Width + Species, data = iris)
     expect_equal(

--- a/tests/testthat/test-fixest.R
+++ b/tests/testthat/test-fixest.R
@@ -14,9 +14,9 @@ osx <- tryCatch(
 
 
 if (!osx &&
-  require("testthat") &&
-  require("insight") &&
-  require("fixest") &&
+  requiet("testthat") &&
+  requiet("insight") &&
+  requiet("fixest") &&
   getRversion() >= "3.6.0") {
   data(trade)
   m1 <- femlm(Euros ~ log(dist_km) | Origin + Destination + Product, data = trade)

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   test_that("format_value", {
     expect_equal(nchar(format_value(1.2012313)), 4)
     expect_equal(format_value(4.2, protect_integers = TRUE), "4.20")

--- a/tests/testthat/test-format_table_ci.R
+++ b/tests/testthat/test-format_table_ci.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   d <- data.frame(CI = 0.97, CI_low = 1, CI_high = 3)
   test_that("format_table with ci-level", {
     ft <- insight::format_table(d)

--- a/tests/testthat/test-formatting.R
+++ b/tests/testthat/test-formatting.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   x <- c(0.0000453, 0.12, 1.2, 0.0001234)
   test_that("format_value", {
     f <- format_value(x, zap_small = FALSE)

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") && require("insight") && require("mgcv")) {
+  if (requiet("testthat") && requiet("insight") && requiet("mgcv")) {
     set.seed(123)
     dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
     m1 <- mgcv::gam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat)

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -3,7 +3,9 @@
 if (.runThisTest) {
   if (requiet("testthat") && requiet("insight") && requiet("mgcv")) {
     set.seed(123)
-    dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
+    void <- capture.output(
+      dat <- mgcv::gamSim(1, n = 400, dist = "normal", scale = 2)
+    )
     m1 <- mgcv::gam(y ~ s(x0) + s(x1) + s(x2) + s(x3), data = dat)
 
     m2 <- download_model("gam_zi_1")

--- a/tests/testthat/test-gamlss.R
+++ b/tests/testthat/test-gamlss.R
@@ -1,15 +1,17 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("gamlss")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("gamlss")) {
   data(abdom)
-  m1 <-
-    gamlss(
-      y ~ pb(x),
-      sigma.formula =  ~ pb(x),
-      family = BCT,
-      data = abdom,
-      method = mixed(1, 20)
-    )
+  void <- capture.output(
+    m1 <-
+      gamlss(
+        y ~ pb(x),
+        sigma.formula =  ~ pb(x),
+        family = BCT,
+        data = abdom,
+        method = mixed(1, 20)
+      )
+  )
 
   test_that("model_info", {
     expect_true(model_info(m1)$is_linear)

--- a/tests/testthat/test-gamm.R
+++ b/tests/testthat/test-gamm.R
@@ -2,7 +2,7 @@
 
 if (.runThisTest) {
   unloadNamespace("gam")
-  if (require("testthat") && require("insight") && require("mgcv")) {
+  if (requiet("testthat") && requiet("insight") && requiet("mgcv")) {
     set.seed(0)
     dat <- gamSim(6, n = 200, scale = .2, dist = "poisson")
     m1 <-

--- a/tests/testthat/test-gamm.R
+++ b/tests/testthat/test-gamm.R
@@ -10,7 +10,8 @@ if (.runThisTest) {
         y ~ s(x0) + s(x1) + s(x2),
         family = poisson,
         data = dat,
-        random = list(fac = ~1)
+        random = list(fac = ~1),
+        verbosePQL = FALSE
       )
 
     test_that("model_info", {
@@ -139,12 +140,16 @@ if (.runThisTest) {
     )
 
     set.seed(0)
-    dat <- gamSim(6, n = 200, scale = .2, dist = "poisson")
+
+    void <- capture.output(
+      dat <- gamSim(6, n = 200, scale = .2, dist = "poisson")
+    )
 
     m2 <- gamm(
       y ~ s(x0) + s(x1) + s(x2),
       family = poisson,
-      data = dat
+      data = dat,
+      verbosePQL = FALSE
     )
 
     dat$g <- dat$fac
@@ -152,7 +157,8 @@ if (.runThisTest) {
       y ~ s(x0) + s(x1) + s(x2),
       family = poisson,
       data = dat,
-      random = list(g = ~1)
+      random = list(g = ~1),
+      verbosePQL = FALSE
     )
 
     test_that("find_formula-gamm-1", {

--- a/tests/testthat/test-gamm4.R
+++ b/tests/testthat/test-gamm4.R
@@ -16,7 +16,7 @@ unloadNamespace("gam")
 
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && !osx && require("testthat") && require("insight") && require("gamm4")) {
+if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet("gamm4")) {
   set.seed(0)
   dat <- gamSim(1, n = 400, scale = 2) ## simulate 4 term additive truth
   dat$fac <- fac <- as.factor(sample(1:20, 400, replace = TRUE))

--- a/tests/testthat/test-gbm.R
+++ b/tests/testthat/test-gbm.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") && require("insight") && require("gbm")) {
+  if (requiet("testthat") && requiet("insight") && requiet("gbm")) {
     set.seed(102) # for reproducibility
     m1 <- gbm(
       mpg ~ gear + cyl + wt,

--- a/tests/testthat/test-gee.R
+++ b/tests/testthat/test-gee.R
@@ -1,8 +1,10 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("gee")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("gee")) {
   data(warpbreaks)
-  m1 <- gee(breaks ~ tension, id = wool, data = warpbreaks)
+  void <- capture.output(suppressMessages(
+    m1 <- gee(breaks ~ tension, id = wool, data = warpbreaks)
+  ))
 
   test_that("model_info", {
     expect_true(model_info(m1)$is_linear)

--- a/tests/testthat/test-geeglm.R
+++ b/tests/testthat/test-geeglm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("geepack")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("geepack")) {
   data(warpbreaks)
   m1 <-
     geeglm(

--- a/tests/testthat/test-get_auxiliary.R
+++ b/tests/testthat/test-get_auxiliary.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("MASS")) {
+if (requiet("testthat") && requiet("insight") && requiet("MASS")) {
   data(quine)
   clotting <- data.frame(
     u = c(5, 10, 15, 20, 30, 40, 60, 80, 100),

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data("cbpp")
   set.seed(123)
   cbpp$cont <- rnorm(nrow(cbpp))

--- a/tests/testthat/test-get_deviance.R
+++ b/tests/testthat/test-get_deviance.R
@@ -15,7 +15,7 @@ osx <- tryCatch(
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
-if (.runThisTest && .runStanTest && !osx && require("testthat") && require("insight") && require("lme4") && require("rstanarm")) {
+if (.runThisTest && .runStanTest && !osx && requiet("testthat") && requiet("insight") && requiet("lme4") && requiet("rstanarm")) {
   data(mtcars)
 
   test_that("get_deviance - Bayesian lm", {

--- a/tests/testthat/test-get_loglikelihood.R
+++ b/tests/testthat/test-get_loglikelihood.R
@@ -14,7 +14,7 @@ osx <- tryCatch(
 
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && !osx && require("testthat") && require("insight") && require("nonnest2")) {
+if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet("nonnest2")) {
   data(iris)
   data(mtcars)
 
@@ -57,7 +57,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
   })
 
   test_that("get_loglikelihood - (g)lmer", {
-    if (require("lme4")) {
+    if (requiet("lme4")) {
       x <- lme4::lmer(Sepal.Length ~ Sepal.Width + (1 | Species), data = iris)
       ll <- loglikelihood(x, estimator = "ML")
       ll2 <- stats::logLik(x)
@@ -74,7 +74,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
 
   test_that("get_loglikelihood - stanreg", {
     .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
-    if (require("rstanarm") && .runStanTest) {
+    if (requiet("rstanarm") && .runStanTest) {
       x <- rstanarm::stan_glm(Sepal.Length ~ Petal.Width, data = iris)
       ref <- lm(Sepal.Length ~ Petal.Width, data = iris)
       ll <- loglikelihood(x)
@@ -85,7 +85,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
   })
 
   test_that("get_loglikelihood - ivreg", {
-    if (require("ivreg")) {
+    if (requiet("ivreg")) {
       data("CigaretteDemand", package = "ivreg")
       x <- ivreg::ivreg(log(packs) ~ log(rprice) + log(rincome) | salestax + log(rincome), data = CigaretteDemand)
 
@@ -95,7 +95,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
   })
 
   test_that("get_loglikelihood - plm", {
-    if (require("plm")) {
+    if (requiet("plm")) {
       data("Produc", package = "plm")
       x <- plm::plm(log(gsp) ~ log(pcap) + log(pc) + log(emp) + unemp,
         data = Produc, index = c("state", "year")
@@ -106,7 +106,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
     }
   })
 
-  if (require("estimatr")) {
+  if (requiet("estimatr")) {
     test_that("get_loglikelihood - iv_robust", {
       data(mtcars)
       x <- estimatr::iv_robust(mpg ~ gear + cyl | carb + wt, data = mtcars)
@@ -116,7 +116,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
     })
   }
 
-  if (require("mgcv")) {
+  if (requiet("mgcv")) {
     test_that("get_loglikelihood - mgcv", {
       x <- mgcv::gam(Sepal.Length ~ s(Petal.Width), data = iris)
       ll <- insight::get_loglikelihood(x)
@@ -129,7 +129,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
       # Which one to get?
     })
   }
-  if (require("gamm4")) {
+  if (requiet("gamm4")) {
     test_that("get_loglikelihood - gamm4", {
       x <- gamm4::gamm4(Sepal.Length ~ s(Petal.Width), data = iris)
       ll <- insight::get_loglikelihood(x)

--- a/tests/testthat/test-get_loglikelihood.R
+++ b/tests/testthat/test-get_loglikelihood.R
@@ -75,7 +75,7 @@ if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet
   test_that("get_loglikelihood - stanreg", {
     .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
     if (requiet("rstanarm") && .runStanTest) {
-      x <- rstanarm::stan_glm(Sepal.Length ~ Petal.Width, data = iris)
+      x <- rstanarm::stan_glm(Sepal.Length ~ Petal.Width, data = iris, refresh = 0)
       ref <- lm(Sepal.Length ~ Petal.Width, data = iris)
       ll <- loglikelihood(x)
       ll2 <- loglikelihood(ref)

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -14,7 +14,7 @@ osx <- tryCatch(
 
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && !osx && require("testthat") && require("insight") && require("lme4") && require("glmmTMB") && require("mgcv") && require("gamm4") && require("rstanarm") && require("merTools") && require("emmeans") && require("bayestestR") && require("mclust") && require("rstantools") && require("psych") && require("fungible")) {
+if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet("lme4") && requiet("glmmTMB") && requiet("mgcv") && requiet("gamm4") && requiet("rstanarm") && requiet("merTools") && requiet("emmeans") && requiet("bayestestR") && requiet("mclust") && requiet("rstantools") && requiet("psych") && requiet("fungible")) {
   data(mtcars)
 
 
@@ -312,7 +312,7 @@ if (.runThisTest && !osx && require("testthat") && require("insight") && require
   # =========================================================================
 
   .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
-  if (require("rstanarm") && .runStanTest) {
+  if (requiet("rstanarm") && .runStanTest) {
 
     test_that("get_predicted - rstanarm", {
       # LM

--- a/tests/testthat/test-get_priors.R
+++ b/tests/testthat/test-get_priors.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
-if (.runThisTest && .runStanTest && require("testthat") && require("insight") && require("brms")) {
+if (.runThisTest && .runStanTest && requiet("testthat") && requiet("insight") && requiet("brms")) {
   data(mtcars)
   set.seed(123)
 

--- a/tests/testthat/test-get_residuals.R
+++ b/tests/testthat/test-get_residuals.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data(mtcars)
   data(sleepstudy)
   data(cbpp)

--- a/tests/testthat/test-get_variance.R
+++ b/tests/testthat/test-get_variance.R
@@ -14,7 +14,7 @@ osx <- tryCatch(
 
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (!osx && .runThisTest && require("testthat") && require("insight") && require("lme4")) {
+if (!osx && .runThisTest && requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data("sleepstudy")
   data("Penicillin")
   set.seed(12345)

--- a/tests/testthat/test-get_weights.R
+++ b/tests/testthat/test-get_weights.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data(mtcars)
   m1 <- lmer(mpg ~ am + (1 | cyl), data = mtcars)
   m2 <- lm(mpg ~ am, data = mtcars)

--- a/tests/testthat/test-glm.R
+++ b/tests/testthat/test-glm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("glmmTMB")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("glmmTMB")) {
   data(Salamanders)
   Salamanders$cover <- abs(Salamanders$cover)
 

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("glmmTMB")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("glmmTMB")) {
   # fish <- read.csv("https://stats.idre.ucla.edu/stat/data/fish.csv")
   # fish$nofish <- as.factor(fish$nofish)
   # fish$livebait <- as.factor(fish$livebait)

--- a/tests/testthat/test-glmrob_base.R
+++ b/tests/testthat/test-glmrob_base.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("robustbase")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("robustbase")) {
   data(carrots)
 
   m1 <- glmrob(

--- a/tests/testthat/test-gls.R
+++ b/tests/testthat/test-gls.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("nlme")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("nlme")) {
   data(Ovary)
   m1 <- gls(follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time),
     Ovary,

--- a/tests/testthat/test-gmnl.R
+++ b/tests/testthat/test-gmnl.R
@@ -6,12 +6,14 @@ if (requiet("testthat") &&
   data(housing, package = "MASS")
 
   dat <- mlogit.data(housing, choice = "Sat", shape = "wide")
-  m1 <-
-    gmnl(Sat ~ Infl + Type + Cont | 1,
-      data = dat,
-      model = "smnl",
-      R = 100
-    )
+  void <- capture.output(
+    m1 <-
+      gmnl(Sat ~ Infl + Type + Cont | 1,
+        data = dat,
+        model = "smnl",
+        R = 100
+      )
+  )
 
   test_that("model_info", {
     expect_false(model_info(m1)$is_ordinal)

--- a/tests/testthat/test-gmnl.R
+++ b/tests/testthat/test-gmnl.R
@@ -1,8 +1,8 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("gmnl") &&
-  require("mlogit") &&
-  require("MASS")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("gmnl") &&
+  requiet("mlogit") &&
+  requiet("MASS")) {
   data(housing, package = "MASS")
 
   dat <- mlogit.data(housing, choice = "Sat", shape = "wide")

--- a/tests/testthat/test-has_intercept.R
+++ b/tests/testthat/test-has_intercept.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data(mtcars)
   data(sleepstudy)
   data(iris)

--- a/tests/testthat/test-htest.R
+++ b/tests/testthat/test-htest.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   x <- t.test(1:3, c(1, 1:3))
   test_that("get_data.t-test", {
     expect_equal(get_data(x)$x, c(1, 2, 3, NA))

--- a/tests/testthat/test-hurdle.R
+++ b/tests/testthat/test-hurdle.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("pscl")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("pscl")) {
   data("bioChemists")
 
   m1 <- hurdle(art ~ fem + mar + kid5 + ment | kid5 + phd, data = bioChemists)

--- a/tests/testthat/test-is_nullmodel.R
+++ b/tests/testthat/test-is_nullmodel.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   data(mtcars)
   data(sleepstudy)
 

--- a/tests/testthat/test-iv_robust.R
+++ b/tests/testthat/test-iv_robust.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("estimatr")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("estimatr")) {
   data(mtcars)
   m1 <- iv_robust(mpg ~ gear + cyl | carb + wt, data = mtcars)
 

--- a/tests/testthat/test-ivreg.R
+++ b/tests/testthat/test-ivreg.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("ivreg")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("ivreg")) {
   data("CigaretteDemand")
   m1 <- ivreg::ivreg(log(packs) ~ log(rprice) + log(rincome) | salestax + log(rincome),
     data = CigaretteDemand

--- a/tests/testthat/test-ivreg_AER.R
+++ b/tests/testthat/test-ivreg_AER.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("AER")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("AER")) {
   data(CigarettesSW)
   CigarettesSW$rprice <- with(CigarettesSW, price / cpi)
   CigarettesSW$rincome <-

--- a/tests/testthat/test-lm.R
+++ b/tests/testthat/test-lm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("stats")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("stats")) {
   data(iris)
   data(mtcars)
 

--- a/tests/testthat/test-lm_robust.R
+++ b/tests/testthat/test-lm_robust.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("estimatr")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("estimatr")) {
   data(mtcars)
   m1 <- lm_robust(mpg ~ gear + wt + cyl, data = mtcars)
 

--- a/tests/testthat/test-lme.R
+++ b/tests/testthat/test-lme.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("nlme") &&
-  require("lme4")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("nlme") &&
+  requiet("lme4")) {
   data("sleepstudy")
   data(Orthodont)
   m1 <- lme(Reaction ~ Days,

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("insight") &&
-  require("lme4")) {
+  requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lme4")) {
   data(sleepstudy)
   set.seed(123)
   sleepstudy$mygrp <- sample(1:5, size = 180, replace = TRUE)

--- a/tests/testthat/test-lmrob_base.R
+++ b/tests/testthat/test-lmrob_base.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("robustbase")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("robustbase")) {
   data(mtcars)
   m1 <- lmrob(mpg ~ gear + wt + cyl, data = mtcars)
 

--- a/tests/testthat/test-lmtest.R
+++ b/tests/testthat/test-lmtest.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("lmtest")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lmtest")) {
   data("Mandible", package = "lmtest")
   m <- lm(length ~ age, data = Mandible, subset = (age <= 28))
   ct1 <- coeftest(m)

--- a/tests/testthat/test-logistf.R
+++ b/tests/testthat/test-logistf.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("logistf")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("logistf")) {
   data(sex2)
   m1 <- logistf(case ~ age + oc + vic + vicl + vis + dia, data = sex2)
 

--- a/tests/testthat/test-metaBMA.R
+++ b/tests/testthat/test-metaBMA.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("insight") && require("metaBMA")) {
+if (.runThisTest && requiet("testthat") && requiet("insight") && requiet("metaBMA")) {
   data(towels)
   set.seed(123)
   mf <- meta_fixed(logOR, SE, study, data = towels, d = prior("norm", c(mean = 0, sd = .3), lower = 0))

--- a/tests/testthat/test-mixed.R
+++ b/tests/testthat/test-mixed.R
@@ -2,10 +2,10 @@
 
 ## TODO enable once it's clear what the problem is...
 
-if (require("testthat") &&
-  require("insight") &&
-  require("lme4") &&
-  suppressPackageStartupMessages(require("afex")) &&
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lme4") &&
+  suppressPackageStartupMessages(requiet("afex")) &&
   FALSE) {
   data(sleepstudy)
 

--- a/tests/testthat/test-mlogit.R
+++ b/tests/testthat/test-mlogit.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("mlogit")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("mlogit")) {
   data("Fishing")
   Fish <-
     mlogit.data(Fishing,

--- a/tests/testthat/test-model_data.R
+++ b/tests/testthat/test-model_data.R
@@ -1,10 +1,10 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("insight") &&
-  require("splines") &&
-  require("glmmTMB")) {
+  requiet("testthat") &&
+  requiet("insight") &&
+  requiet("splines") &&
+  requiet("glmmTMB")) {
   data(iris)
 
   m1 <- lm(Sepal.Length ~ Species + ns(Petal.Width), data = iris)

--- a/tests/testthat/test-model_info.R
+++ b/tests/testthat/test-model_info.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("BayesFactor")) {
+if (requiet("testthat") && requiet("insight") && requiet("BayesFactor")) {
   model <- BayesFactor::proportionBF(15, 25, p = 0.5)
   mi <- insight::model_info(model)
   test_that("model_info-BF-proptest", {

--- a/tests/testthat/test-multinom.R
+++ b/tests/testthat/test-multinom.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("nnet") &&
-  require("MASS")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("nnet") &&
+  requiet("MASS")) {
   data("birthwt")
   m1 <- multinom(low ~ age + lwt + race + smoke, data = birthwt)
 

--- a/tests/testthat/test-mvrstanarm.R
+++ b/tests/testthat/test-mvrstanarm.R
@@ -2,9 +2,9 @@
 .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
 if (.runThisTest && .runStanTest &&
-  suppressWarnings(require("testthat") &&
-    require("insight") &&
-    require("rstanarm"))) {
+  suppressWarnings(requiet("testthat") &&
+    requiet("insight") &&
+    requiet("rstanarm"))) {
   data("pbcLong")
   m1 <- download_model("stanmvreg_1")
 

--- a/tests/testthat/test-n_parameters_rank-deficiency.R
+++ b/tests/testthat/test-n_parameters_rank-deficiency.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight")) {
+if (requiet("testthat") && requiet("insight")) {
   set.seed(123)
   data(mtcars)
   m <- lm(formula = wt ~ am * cyl * vs, data = mtcars)

--- a/tests/testthat/test-namespace.R
+++ b/tests/testthat/test-namespace.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("splines")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("splines")) {
   data(iris)
   m1 <- lm(Sepal.Length ~ splines::bs(Petal.Width, df = 4) + Species, data = iris)
 

--- a/tests/testthat/test-negbin.R
+++ b/tests/testthat/test-negbin.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest && Sys.getenv("USER") != "travis") {
-  if (require("testthat") && require("insight") && require("aod")) {
+  if (requiet("testthat") && requiet("insight") && requiet("aod")) {
     data(dja)
     m1 <-
       suppressWarnings(aod::negbin(y ~ group + offset(log(trisk)),

--- a/tests/testthat/test-nlmer.R
+++ b/tests/testthat/test-nlmer.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("lme4")) {
+if (requiet("testthat") && requiet("insight") && requiet("lme4")) {
   set.seed(123)
   startvec <- c(Asym = 200, xmid = 725, scal = 350)
   nm1 <-

--- a/tests/testthat/test-offset.R
+++ b/tests/testthat/test-offset.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("pscl")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("pscl")) {
   # Generate some zero-inflated data
   set.seed(123)
   N <- 100 # Samples

--- a/tests/testthat/test-ols.R
+++ b/tests/testthat/test-ols.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("rms")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("rms")) {
   data(mtcars)
   m1 <- ols(mpg ~ rcs(hp, 3) * cyl + wt, data = mtcars)
 

--- a/tests/testthat/test-panelr.R
+++ b/tests/testthat/test-panelr.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("panelr")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("panelr")) {
   data("WageData")
   wages <- panel_data(WageData, id = id, wave = t)
   m1 <- wbm(lwage ~ lag(union) + wks | blk + fem | blk * lag(union), data = wages)

--- a/tests/testthat/test-plm.R
+++ b/tests/testthat/test-plm.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest && getRversion() > "3.5") {
-  if (require("testthat") && require("insight") && require("plm")) {
+  if (requiet("testthat") && requiet("insight") && requiet("plm")) {
     data(Crime)
     m1 <- plm(lcrmrte ~ lprbarr + factor(year) | . - lprbarr + lmix, data = Crime, model = "random")
 

--- a/tests/testthat/test-polr.R
+++ b/tests/testthat/test-polr.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("MASS")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("MASS")) {
   data(housing, package = "MASS")
 
   m1 <- polr(Sat ~ Infl + Type + Cont, data = housing, weights = Freq)

--- a/tests/testthat/test-proportion_response.R
+++ b/tests/testthat/test-proportion_response.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("lme4")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lme4")) {
   data(mtcars)
 
   m1 <- glmer(

--- a/tests/testthat/test-psm.R
+++ b/tests/testthat/test-psm.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("rms")) {
+if (requiet("testthat") && requiet("insight") && requiet("rms")) {
   n <- 400
   set.seed(1)
   age <- rnorm(n, 50, 12)

--- a/tests/testthat/test-r3_4.R
+++ b/tests/testthat/test-r3_4.R
@@ -1,6 +1,6 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
-if (.runThisTest && require("testthat") && require("insight")) {
+if (.runThisTest && requiet("testthat") && requiet("insight")) {
   data(mtcars)
   m <- glm(am ~ mpg, mtcars, family = binomial())
   test_that("find_random", {

--- a/tests/testthat/test-response_data2.R
+++ b/tests/testthat/test-response_data2.R
@@ -1,6 +1,6 @@
-if (suppressWarnings(require("testthat") &&
-  require("insight") &&
-  require("lme4"))) {
+if (suppressWarnings(requiet("testthat") &&
+  requiet("insight") &&
+  requiet("lme4"))) {
   data(cbpp)
   cbpp$trials <- cbpp$size - cbpp$incidence
 

--- a/tests/testthat/test-rlmer.R
+++ b/tests/testthat/test-rlmer.R
@@ -1,8 +1,8 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest) {
-  if (require("testthat") &&
-    require("insight") && require("lme4") && require("robustlmm")) {
+  if (requiet("testthat") &&
+    requiet("insight") && requiet("lme4") && requiet("robustlmm")) {
     data(sleepstudy)
 
     set.seed(123)

--- a/tests/testthat/test-rms.R
+++ b/tests/testthat/test-rms.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("rms")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("rms")) {
   data(mtcars)
   m1 <- lrm(am ~ mpg + gear, data = mtcars)
 

--- a/tests/testthat/test-rq.R
+++ b/tests/testthat/test-rq.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("quantreg")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("quantreg")) {
   data(stackloss)
   m1 <-
     rq(stack.loss ~ Air.Flow + Water.Temp,

--- a/tests/testthat/test-rqss.R
+++ b/tests/testthat/test-rqss.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("quantreg") &&
-  require("tripack")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("quantreg") &&
+  requiet("tripack")) {
   data("CobarOre")
   set.seed(123)
   CobarOre$w <- rnorm(nrow(CobarOre))

--- a/tests/testthat/test-rstanarm.R
+++ b/tests/testthat/test-rstanarm.R
@@ -2,10 +2,10 @@
 .runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
 if (.runThisTest && .runStanTest) {
-  if (suppressWarnings(require("testthat") &&
-    require("insight") && require("lme4") &&
-    require("BayesFactor") &&
-    require("rstanarm"))) {
+  if (suppressWarnings(requiet("testthat") &&
+    requiet("insight") && requiet("lme4") &&
+    requiet("BayesFactor") &&
+    requiet("rstanarm"))) {
 
     # skip_on_cran()
 

--- a/tests/testthat/test-spatial.R
+++ b/tests/testthat/test-spatial.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest || Sys.getenv("USER") == "travis") {
-  if (require("testthat") && require("insight") && require("glmmTMB")) {
+  if (requiet("testthat") && requiet("insight") && requiet("glmmTMB")) {
     m1 <- download_model("glmmTMB_spatial_1")
 
     test_that("find_weights", {

--- a/tests/testthat/test-speedglm.R
+++ b/tests/testthat/test-speedglm.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("speedglm") &&
-  require("glmmTMB")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("speedglm") &&
+  requiet("glmmTMB")) {
   data(Salamanders)
   Salamanders$cover <- abs(Salamanders$cover)
 

--- a/tests/testthat/test-speedlm.R
+++ b/tests/testthat/test-speedlm.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("speedglm")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("speedglm")) {
   data(iris)
   data(mtcars)
 

--- a/tests/testthat/test-standardize_names.R
+++ b/tests/testthat/test-standardize_names.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("stats") &&
-  require("parameters")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("stats") &&
+  requiet("parameters")) {
   .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
   if (packageVersion("parameters") >= "0.14.0") {

--- a/tests/testthat/test-survey.R
+++ b/tests/testthat/test-survey.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("survey")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("survey")) {
   data(api)
   dstrat <-
     svydesign(

--- a/tests/testthat/test-survfit.R
+++ b/tests/testthat/test-survfit.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("survival")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("survival")) {
   m1 <- survfit(Surv(time, status) ~ sex + age + ph.ecog, data = lung)
 
   test_that("model_info", {

--- a/tests/testthat/test-survreg.R
+++ b/tests/testthat/test-survreg.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("survival")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("survival")) {
   m1 <- survreg(Surv(futime, fustat) ~ ecog.ps + rx,
     data = ovarian,
     dist = "exponential"

--- a/tests/testthat/test-tidymodels.R
+++ b/tests/testthat/test-tidymodels.R
@@ -1,9 +1,9 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest &&
-  require("testthat") &&
-  require("insight") &&
-  require("parsnip")) {
+  requiet("testthat") &&
+  requiet("insight") &&
+  requiet("parsnip")) {
   data(mtcars)
 
   m <- parsnip::linear_reg()

--- a/tests/testthat/test-tobit.R
+++ b/tests/testthat/test-tobit.R
@@ -1,4 +1,4 @@
-if (require("testthat") && require("insight") && require("AER")) {
+if (requiet("testthat") && requiet("insight") && requiet("AER")) {
   data("Affairs", package = "AER")
   m1 <-
     AER::tobit(affairs ~ age + yearsmarried + religiousness + occupation + rating,

--- a/tests/testthat/test-truncreg.R
+++ b/tests/testthat/test-truncreg.R
@@ -1,7 +1,7 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("truncreg") &&
-  require("survival")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("truncreg") &&
+  requiet("survival")) {
   data("tobin", package = "survival")
   m1 <- truncreg(durable ~ age + quant, data = tobin, subset = durable > 0)
 

--- a/tests/testthat/test-vgam.R
+++ b/tests/testthat/test-vgam.R
@@ -1,7 +1,7 @@
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
 
 if (.runThisTest && Sys.getenv("USER") != "travis") {
-  if (require("testthat") && require("insight") && require("VGAM")) {
+  if (requiet("testthat") && requiet("insight") && requiet("VGAM")) {
     data("hunua")
     m1 <- download_model("vgam_1")
     m2 <- download_model("vgam_2")

--- a/tests/testthat/test-vglm.R
+++ b/tests/testthat/test-vglm.R
@@ -1,6 +1,6 @@
 unloadNamespace("gam")
 
-if (require("testthat") && require("insight") && require("VGAM")) {
+if (requiet("testthat") && requiet("insight") && requiet("VGAM")) {
   d.AD <- data.frame(
     treatment = gl(3, 3),
     outcome = gl(3, 1, 9),
@@ -12,7 +12,7 @@ if (require("testthat") && require("insight") && require("VGAM")) {
       counts ~ outcome + treatment,
       family = poissonff,
       data = d.AD,
-      trace = TRUE
+      trace = FALSE
     )
 
   test_that("model_info", {

--- a/tests/testthat/test-zeroinfl.R
+++ b/tests/testthat/test-zeroinfl.R
@@ -1,6 +1,6 @@
-if (require("testthat") &&
-  require("insight") &&
-  require("pscl")) {
+if (requiet("testthat") &&
+  requiet("insight") &&
+  requiet("pscl")) {
   data("bioChemists")
 
   m1 <- zeroinfl(art ~ fem + mar + kid5 + ment | kid5 + phd, data = bioChemists)


### PR DESCRIPTION
This PR is mainly for aesthetics. Feel free to ignore if you don't think this is a good idea.

The `insight` package is different from most because the test suite must load a bunch of different packages. Many of those print messages on `require`, which makes the `testthat` log basically unreadable.

This PR introduces a helper function called `requiet` (isn't this cute?!) which requires packages but suppresses startup messages:

```r
requiet <- function(package) {
  suppressPackageStartupMessages(
    require(package, warn.conflicts = FALSE, character.only = TRUE)
  )
}
```

This is WORK IN PROGRESS; DO NOT MERGE. I want to look at what the `testthat` log looks like on Github actions before moving forward with this.

