### PR TITLE
get_predicted: `type` vs. `predict` disambiguation

### DIFF
--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -10,9 +10,9 @@
 #' * `"link"` returns predictions on the model's link-scale (for logistic models, that means the log-odds scale) with a confidence interval (CI).
 #' * `"expectation"` (default) also returns confidence intervals, but this time the output is on the response scale (for logistic models, that means probabilities).
 #' * `"prediction"` also gives an output on the response scale, but this time associated with a prediction interval (PI), which is larger than a confidence interval (though it mostly make sense for linear models).
-#' * `"classification"` only differs from `"predict"` for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor).
-#' * Other strings are passed directly to the `type` argument of the `predict` method supplied by the modelling package.
-#' * When `predict = NULL`, alternative arguments such as `type` will be captured by the `...` ellipsis and passed directly to the `predict` method supplied by the modelling package.
+#' * `"classification"` only differs from `"prediction"` for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor).
+#' * Other strings are passed directly to the `type` argument of the `predict()` method supplied by the modelling package.
+#' * When `predict = NULL`, alternative arguments such as `type` will be captured by the `...` ellipsis and passed directly to the `predict()` method supplied by the modelling package.
 #' * Notes: You can see the 4 options for predictions as on a gradient from "close to the model" to "close to the response data": "link", "expectation", "prediction", "classification". The `predict` argument modulates two things: the scale of the output and the type of certainty interval. Read more about in the **Details** section below.
 #' @param iterations For Bayesian models, this corresponds to the number of
 #'   posterior draws. If `NULL`, will return all the draws (one for each
@@ -616,7 +616,8 @@ get_predicted.faMain <- function(x, data = NULL, ...) {
   # check `predict` user-input
   supported <- c("expectation", "link", "prediction", "classification")
   if (isTRUE(verbose) && !is.null(predict) && !predict %in% supported) {
-    warning(sprintf('"%s" is not officially supported by the `get_predicted` function as a value for the `predict` argument. It will not be processed or validated, and will be passed directly to the `predict` method supplied by the modeling package. Users are encouraged to check the validity and scale of the results. Set `verbose=FALSE` to silence this warning, or use one of the supported values for the `predict` argument: %s.', predict, paste(sprintf('"%s"', supported), collapse = ", ")))
+    msg <- format_message(sprintf('"%s" is not officially supported by the `get_predicted` function as a value for the `predict` argument. It will not be processed or validated, and will be passed directly to the `predict` method supplied by the modeling package. Users are encouraged to check the validity and scale of the results. Set `verbose=FALSE` to silence this warning, or use one of the supported values for the `predict` argument: %s.', predict, paste(sprintf('"%s"', supported), collapse = ", ")))
+    warning(msg)
   }
 
   # Arbitrate conflicts between the `predict` and `type` from the ellipsis. We
@@ -627,7 +628,7 @@ get_predicted.faMain <- function(x, data = NULL, ...) {
   if (is.null(dots$type)) {
     predict_arg <- predict
     if (is.null(predict)) {
-      stop("Please supply a value for the `predict` argument.")
+      stop(format_message("Please supply a value for the `predict` argument."))
     }
   } else {
     if(is.null(predict)) {

--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -111,8 +111,8 @@
 #' pred <- get_predicted(x, predict = "link")
 #' head(as.data.frame(pred))
 #'
-#' # Response: response "type" + PI
-#' pred <- get_predicted(x, predict = "response")
+#' # Classification: classification "type" + PI
+#' pred <- get_predicted(x, predict = "classification")
 #' head(as.data.frame(pred))
 #' @export
 get_predicted <- function(x, ...) {
@@ -267,7 +267,7 @@ get_predicted.merMod <- get_predicted.lmerMod
 #' @export
 get_predicted.glmmTMB <- function(x,
                                   data = NULL,
-                                  predict = c("expectation", "link", "prediction", "response", "classification"),
+                                  predict = c("expectation", "link", "prediction", "classification"),
                                   ci = 0.95,
                                   include_random = TRUE,
                                   iterations = NULL,
@@ -343,7 +343,7 @@ get_predicted.glmmTMB <- function(x,
 #' @export
 get_predicted.gam <- function(x,
                               data = NULL,
-                              predict = c("expectation", "link", "prediction", "response", "classification"),
+                              predict = c("expectation", "link", "prediction", "classification"),
                               ci = 0.95,
                               include_random = TRUE,
                               include_smooth = TRUE,

--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -723,8 +723,8 @@ get_predicted.faMain <- function(x, data = NULL, ...) {
     predictions <- as.factor(predictions)
     levels(predictions) <- levels(response)
   } else {
-    predictions[predictions == 0] <- unique(response)[1]
-    predictions[predictions == 1] <- unique(response)[2]
+    resp <- unique(response)
+    predictions <- resp[match(predictions, resp)]
   }
   predictions
 }

--- a/man/get_predicted.Rd
+++ b/man/get_predicted.Rd
@@ -43,9 +43,9 @@ to predict. If omitted, the data used to fit the model is used.}
 \item \code{"link"} returns predictions on the model's link-scale (for logistic models, that means the log-odds scale) with a confidence interval (CI).
 \item \code{"expectation"} (default) also returns confidence intervals, but this time the output is on the response scale (for logistic models, that means probabilities).
 \item \code{"prediction"} also gives an output on the response scale, but this time associated with a prediction interval (PI), which is larger than a confidence interval (though it mostly make sense for linear models).
-\item \code{"classification"} only differs from \code{"predict"} for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor).
-\item Other strings are passed directly to the \code{type} argument of the \code{predict} method supplied by the modelling package.
-\item When \code{predict = NULL}, alternative arguments such as \code{type} will be captured by the \code{...} ellipsis and passed directly to the \code{predict} method supplied by the modelling package.
+\item \code{"classification"} only differs from \code{"prediction"} for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor).
+\item Other strings are passed directly to the \code{type} argument of the \code{predict()} method supplied by the modelling package.
+\item When \code{predict = NULL}, alternative arguments such as \code{type} will be captured by the \code{...} ellipsis and passed directly to the \code{predict()} method supplied by the modelling package.
 \item Notes: You can see the 4 options for predictions as on a gradient from "close to the model" to "close to the response data": "link", "expectation", "prediction", "classification". The \code{predict} argument modulates two things: the scale of the output and the type of certainty interval. Read more about in the \strong{Details} section below.
 }}
 

--- a/man/get_predicted.Rd
+++ b/man/get_predicted.Rd
@@ -148,8 +148,8 @@ head(as.data.frame(pred))
 pred <- get_predicted(x, predict = "link")
 head(as.data.frame(pred))
 
-# Response: response "type" + PI
-pred <- get_predicted(x, predict = "response")
+# Classification: classification "type" + PI
+pred <- get_predicted(x, predict = "classification")
 head(as.data.frame(pred))
 }
 \seealso{

--- a/man/get_predicted.Rd
+++ b/man/get_predicted.Rd
@@ -38,7 +38,16 @@ second argument has to be a model).}
 \item{data}{An optional data frame in which to look for variables with which
 to predict. If omitted, the data used to fit the model is used.}
 
-\item{predict}{Can be \code{"link"}, \code{"expectation"} (default), \code{"prediction"}, or \code{"response"}. You can see these 4 options for predictions as on a gradient from "close to the model" to "close to the response data". More specifically, the \code{predict} argument modulates two things; the scale of the output as well as the type of certainty interval (see the details and examples). More specifically, \code{"link"} returns predictions on the model's link-scale (for logistic models, that means the log-odds scale) with a confidence interval (CI). \code{"expectation"} (default) also returns confidence intervals, but this time the output is on the response scale (for logistic models, that means probabilities). \code{"predict"} also gives an output on the response scale, but this time associated with a prediction interval (PI), which is larger than a confidence interval (though it mostly make sense for linear models). Finally, \code{"response"} only differs from the previous option for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor). Read more about in the \strong{Details} section below.}
+\item{predict}{string or \code{NULL}
+\itemize{
+\item \code{"link"} returns predictions on the model's link-scale (for logistic models, that means the log-odds scale) with a confidence interval (CI).
+\item \code{"expectation"} (default) also returns confidence intervals, but this time the output is on the response scale (for logistic models, that means probabilities).
+\item \code{"prediction"} also gives an output on the response scale, but this time associated with a prediction interval (PI), which is larger than a confidence interval (though it mostly make sense for linear models).
+\item \code{"classification"} only differs from \code{"predict"} for binomial models where it additionally transforms the predictions into the original response's type (for instance, to a factor).
+\item Other strings are passed directly to the \code{type} argument of the \code{predict} method supplied by the modelling package.
+\item When \code{predict = NULL}, alternative arguments such as \code{type} will be captured by the \code{...} ellipsis and passed directly to the \code{predict} method supplied by the modelling package.
+\item Notes: You can see the 4 options for predictions as on a gradient from "close to the model" to "close to the response data": "link", "expectation", "prediction", "classification". The \code{predict} argument modulates two things: the scale of the output and the type of certainty interval. Read more about in the \strong{Details} section below.
+}}
 
 \item{iterations}{For Bayesian models, this corresponds to the number of
 posterior draws. If \code{NULL}, will return all the draws (one for each

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -443,7 +443,6 @@ test_that("`predict()` vs. `get_predicted` link equivalence", {
 })
 
 
-
 test_that("hurdle: get_predicted matches `predict()`", {
     skip_if_not_installed("pscl")
     data("bioChemists", package = "pscl")
@@ -457,18 +456,10 @@ test_that("hurdle: get_predicted matches `predict()`", {
 })
 
 
-
-# bugfix in .get_predict_transform_response ----------
-# ====================================================
-
-test_that("bugfix: predict='response' returns all zeros", {
+test_that("bugfix: used to return all zeros", {
   mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
   pred <- expect_warning(get_predicted(mod, predict = "response"))
   expect_false(any(pred == 0))
+  pred <- get_predicted(mod, predict = "original")
+  expect_false(all(pred == 0))
 })
-
-# test_that("bugfix: predict='original' returns all zeros", {
-#   mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
-#   pred <- get_predicted(mod, predict = "original")
-#   expect_false(any(pred == 0))
-# })

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -357,7 +357,7 @@ if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet
 
   # FA / PCA ----------------------------------------------------------------
   # =========================================================================
-  3
+  
   test_that("get_predicted - FA / PCA", {
     # PCA
     x <- get_predicted(psych::principal(mtcars, 3))
@@ -383,10 +383,92 @@ if (.runThisTest && !osx && requiet("testthat") && requiet("insight") && requiet
 }
 
 
+# arguments: `predict` vs. `type` -----------------------------------------
+# =========================================================================
 
-test_that("check SE against barebones `predict`", {
+test_that("lm: get_predicted vs barebones `predict()`", {
   mod <- lm(mpg ~ hp + factor(cyl), mtcars)
-  known <- predict(mod, se.fit = TRUE)$se.fit
-  unknown <- as.data.frame(get_predicted(mod))$SE
-  expect_equal(known, unknown)
+  known <- predict(mod, se.fit = TRUE, interval = "confidence")
+  unknown1 <- as.data.frame(get_predicted(mod))
+  unknown2 <- as.data.frame(get_predicted(mod, predict = "expectation"))
+  unknown3 <- expect_warning(as.data.frame(get_predicted(mod, predict = "response")))
+  expect_equal(unname(known$fit[, "fit"]), unknown1$Predicted)
+  expect_equal(unname(known$se.fit), unknown1$SE)
+  expect_equal(unname(known$fit[, "lwr"]), unknown1$CI_low)
+  expect_equal(unname(known$fit[, "upr"]), unknown1$CI_high)
+  expect_equal(unname(known$fit[, "fit"]), unknown2$Predicted)
+  expect_equal(unname(known$se.fit), unknown2$SE)
+  expect_equal(unname(known$fit[, "lwr"]), unknown2$CI_low)
+  expect_equal(unname(known$fit[, "upr"]), unknown2$CI_high)
+  expect_equal(unname(known$fit[, "fit"]), unknown3$Predicted)
+  expect_equal(unname(known$se.fit), unknown3$SE)
+  expect_equal(unname(known$fit[, "lwr"]), unknown3$CI_low)
+  expect_equal(unname(known$fit[, "upr"]), unknown3$CI_high)
 })
+
+
+test_that("using both `predict` and `type` raises an informative error", {
+  mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+  expect_warning(expect_error(
+    get_predicted(mod, predict = "response", type = "response")))
+})
+
+
+test_that("`predict` and `type` are both `NULL`", {
+  mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+  expect_error(get_predicted(mod, predict = NULL), regexp = "supply")
+})
+
+
+test_that("`predict()` vs. `get_predicted` link equivalence", {
+  # link
+  mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+  known <- predict(mod, type = "link", interval = "confidence", se.fit = TRUE)
+  unknown <- as.data.frame(get_predicted(mod, predict = NULL, type = "link"))
+  expect_equal(unname(known$fit), unknown$Predicted)
+  expect_equal(unname(known$se.fit), unknown$SE)
+  
+  # response
+  mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+  known <- predict(mod, type = "response", se.fit = TRUE)
+  unknown1 <- as.data.frame(get_predicted(mod, predict = "expectation"))
+  unknown2 <- as.data.frame(get_predicted(mod, predict = NULL, type = "response"))
+  unknown3 <- expect_warning(as.data.frame(get_predicted(mod, predict = "response")))
+  expect_equal(unname(known$fit), unknown1$Predicted)
+  expect_equal(unname(known$se.fit), unknown1$SE)
+  expect_equal(unname(known$fit), unknown2$Predicted)
+  expect_equal(unname(known$se.fit), unknown2$SE)
+  expect_equal(unname(known$fit), unknown3$Predicted)
+  expect_equal(unname(known$se.fit), unknown3$SE)
+})
+
+
+
+test_that("hurdle: get_predicted matches `predict()`", {
+    skip_if_not_installed("pscl")
+    data("bioChemists", package = "pscl")
+    mod <- pscl::hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+    known <- predict(mod, type = "response")
+    unknown <- get_predicted(mod, type = "response")
+    expect_equal(known, unknown)
+    known <- predict(mod, type = "zero")
+    unknown <- get_predicted(mod, type = "zero")
+    expect_equal(known, unknown)
+})
+
+
+
+# bugfix in .get_predict_transform_response ----------
+# ====================================================
+
+test_that("bugfix: predict='response' returns all zeros", {
+  mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+  pred <- expect_warning(get_predicted(mod, predict = "response"))
+  expect_false(any(pred == 0))
+})
+
+# test_that("bugfix: predict='original' returns all zeros", {
+#   mod <- glm(am ~ hp + factor(cyl), family = binomial, data = mtcars)
+#   pred <- get_predicted(mod, predict = "original")
+#   expect_false(any(pred == 0))
+# })


### PR DESCRIPTION
This is a PR to address issue #431  

I included a bunch of new tests, and what feels like "conservative" warnings and errors.

From my perspective, the main thing that still needs to be hashed out is what to do with the current `predict="response"` argument value. In Issue #432, there are some suggestions for different naming convention. At this stage, I would actually advocate removing it altogether for the reasons stated in the other issue. 
 
Any feedback would be much appreciated! I'm happy to make any change you deem necessary.