### PR TITLE
bugfix: get_predicted uses newdata

### DIFF
--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -129,7 +129,7 @@ get_predicted <- function(x, ...) {
 #' @export
 get_predicted.default <- function(x, data = NULL, verbose = TRUE, ...) {
 
-  args <- c(list(x, "data" = data), list(...))
+  args <- c(list(x, "newdata" = data), list(...))
 
   out <- tryCatch(do.call("predict", args), error = function(e) NULL)
 


### PR DESCRIPTION
Fixing a bug that I introduced myself. `get_predicted.default` should call `predict` using the `newdata` argument instead of `data`.