### PR TITLE
get_predicted.glmmTMB tests and not transformations

### DIFF
--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -433,15 +433,14 @@ get_predicted.glmmTMB <- function(x,
                                   iterations = NULL,
                                   verbose = TRUE,
                                   ...) {
-  predict <- match.arg(predict, choices = c("expectation", "expected", "link", "prediction", "predicted", "classification"))
 
   # Sanity checks
-  if (predict %in% c("prediction", "predicted")) {
+  if (!is.null(predict) && predict %in% c("prediction", "predicted", "classification")) {
     if (verbose) {
       warning(
         format_message(
-          "`predict='prediction'` is currently not available for glmmTMB models.",
-          "Changing to `predict='expectation'`."
+          '"prediction" and "classification" are not currently not available in the `predict`',
+          'argument for glmmTMB models. Changing to `predict="expectation"`.'
         ),
         call. = FALSE
       )
@@ -467,7 +466,7 @@ get_predicted.glmmTMB <- function(x,
     stats::predict(
       x,
       newdata = data,
-      type = args$type,
+      type = args$scale,
       re.form = args$re.form,
       unconditional = FALSE,
       ...
@@ -492,8 +491,7 @@ get_predicted.glmmTMB <- function(x,
 
   # Get CI
   ci_data <- .get_predicted_se_to_ci(x, predictions = predictions, se = rez$se.fit, ci = ci)
-  out <- .get_predicted_transform(x, predictions, args, ci_data)
-  .get_predicted_out(out$predictions, args = args, ci_data = out$ci_data)
+  .get_predicted_out(predictions, args = args, ci_data = ci_data)
 }
 
 

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -760,6 +760,39 @@ if (requiet("testthat") &&
     )
   })
 
+  test_that("get_predicted", {
+
+    # response
+    x <- get_predicted(m1, predict = "expectation")
+    y <- get_predicted(m1, predict = NULL, type = "response")
+    z <- predict(m1, type = "response")
+    expect_equal(x, y, ignore_attr = TRUE)
+    expect_equal(y, z, ignore_attr = TRUE)
+    expect_equal(x, z, ignore_attr = TRUE)
+
+    # link
+    x <- get_predicted(m1, predict = "link")
+    y <- get_predicted(m1, predict = NULL, type = "link")
+    z <- predict(m1, type = "link")
+    expect_equal(x, y, ignore_attr = TRUE)
+    expect_equal(y, z, ignore_attr = TRUE)
+    expect_equal(x, z, ignore_attr = TRUE)
+
+    # unsupported: zprob
+    x <- suppressWarnings(get_predicted(m1, predict = "zprob"))
+    y <- get_predicted(m1, predict = NULL, type = "zprob")
+    z <- predict(m1, type = "zprob")
+    expect_equal(x, y)
+    expect_equal(x, z, ignore_attr = TRUE)
+
+    # not official supported raise warning
+    expect_warning(get_predicted(m1, predict = "prediction"))
+    expect_warning(get_predicted(m1, predict = "classification"))
+    expect_warning(get_predicted(m1, predict = "zprob"))
+    expect_warning(get_predicted(m1, predict = "zprob", verbose = FALSE), NA)
+
+  })
+
   test_that("clean_parameters", {
     expect_equal(
       clean_parameters(m1),


### PR DESCRIPTION
This PR is related to #413. It might be a bit more controversial than the others, so I’ll leave it here for a bit to give people a chance to comment.

I removed the call to `.get_predicted_transform` from `get_predicted.glmmTMB` because I think it produced incorrect results:

``` r
library(insight)
library(glmmTMB)

m <- glmmTMB(count ~ spp + mined + (1 | site),
             zi = ~ spp + mined,
             family = nbinom2, data = Salamanders)

unknown <- get_predicted(m, predict = "expectation")
known <- predict(m, type = "response", se.fit = TRUE)

unknown |> as.data.frame() |> head()
#   Predicted        SE     CI_low  CI_high
# 1 0.5387752 0.2504592 0.21662650 1.339996
# 2 1.0768783 0.3636606 0.55554192 2.087452
# 3 0.3554236 0.2528622 0.08813904 1.433258
# 4 2.4701755 0.6106873 1.52156375 4.010195
# 5 2.4950498 0.6142041 1.54006744 4.042208
# 6 2.1819828 0.5595765 1.31995150 3.606988

known$fit |> head()
# mu_predict mu_predict mu_predict mu_predict mu_predict mu_predict 
#  0.1546241  0.3090553  0.1020037  2.0732045  2.0940814  1.8313260

known$se.fit |> head()
# mu_predict mu_predict mu_predict mu_predict mu_predict mu_predict 
# 0.07476462 0.15006330 0.06712653 0.52401542 0.50728643 0.45872776
```

The documentation of the `predict.glmmTMB()` function states:

> "response" expected value; this is mu*(1-p) for zero-inflated models and ‘mu’ otherwise

So the fact that `response` does not equal `expectation` is surprising.

I’m not sure it’s my place to open a big philosophical debate about this, but I would argue that `insight` should do its best to *avoid* making automatic transformations to numerical values in general, and to the scale of predicted values in particular. The mission statement of the package on CRAN is:

> “A tool to provide an easy, intuitive and consistent access to information contained in various R models”

So I think we should concentrate on *access* to information, and not on *transformation* of information. For example, providing a “dictionary” of common response types makes sense, because many models share types but use different naming conventions. So we make things more uniform. But automagically transforming the scale of the response can be dangerous – as illustrated by the code above – and it’s a very very deep rabbit hole that makes the codebase hard to understand and hard to manage.

For `insight` to play a role as an infrastructure package, it’s crucial that it *never* produce erroneous or suprising results. Avoiding transformations, keeping things simple, and sticking close to the modelling package’s information feels like a safer strategy.

Anyway, just my 2 cents. Feel free to ignore or tell me it's all dumb ;)