### PR TITLE
Fix get_sigma() for brms and glmmTMB models

### DIFF
--- a/R/get_sigma.R
+++ b/R/get_sigma.R
@@ -125,7 +125,7 @@ get_sigma <- function(x, ci = NULL, verbose = TRUE) {
       } else if (length(sigma_column)) {
         # if more than one sigma column,
         # there isn't a traditional sigma for the model
-        NA
+        return(NULL)
       } else {
         NULL
       }
@@ -194,7 +194,7 @@ get_sigma <- function(x, ci = NULL, verbose = TRUE) {
   if (.is_empty_object(s)) {
     info <- model_info(x)
     if (!is.null(info) && info$is_dispersion) {
-      s <- NA
+      return(NULL)
     }
   }
 


### PR DESCRIPTION
Currently, `get_sigma()` is returning erroneous results for glmmTMB or brms models with dispersion models (sigma formulas). glmmTMB is erroneous because it returns a value based on the deviance. I'm not sure that that is generally a good idea, at least outside of OLS models. brms is erroneous because it simply returns the first "sigma" column from the parameters, which isn't a traditional "sigma" parameter (there is either more than 1 sigma or there is no sigma at all--sigma is defined by the sigma model, not a single value). 

In this PR, I return NULL for `get_sigma()` in these cases. We could altenativey return `NA` with the `insight_aux` classes?


```r
library(glmmTMB)
library(brms)
exp_data <- data.frame(
  g = factor(c(rep("c", 100), rep("e", 100))),
  y = c(rnorm(100, 0, 2), rnorm(100, 4, 4))
)
m1 <- glmmTMB(y ~ g, dispformula = ~ g, data = exp_data)
m2 <- brm(bf(y ~ g, sigma ~ g), data = exp_data)

# should be 1 or NA
insight::get_sigma(m1)
insight::get_sigma(m2)

```