### PR TITLE
get_predicted.brms works with predict=NULL and type=response

### DIFF
--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -782,6 +782,17 @@ get_predicted.stanreg <- function(x,
     ...
   )
 
+  # when the `type` argument is passed through ellipsis, we need to manually set
+  # the `args$predict` value, because this is what determines which `rstantools`
+  # function we will use to draw from the posterior predictions.
+  dots <- list(...)
+  if (is.null(predict) && "type" %in% names(dots)) {
+    if (dots$type == "link") {
+      args$predict <- "link"
+    } else if (dots$type == "response") {
+      args$predict <- "expectation"
+    }
+  }
 
   # Get draws
   if (args$predict %in% c("link")) {

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -2,6 +2,7 @@ run_stan <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
 pkgs <- c(
   "lme4",
+  "brms",
   "glmmTMB",
   "mgcv",
   "gamm4",
@@ -476,4 +477,21 @@ test_that("bugfix: used to return all zeros", {
   pred <- suppressWarnings(get_predicted(mod, predict = "original"))
   expect_warning(get_predicted(mod, predict = "original"))
   expect_false(all(pred == 0))
+})
+
+
+test_that("brms: `type` in ellipsis used to produce the wrong intervals", {
+  skip_if(isFALSE(run_stan))
+  skip_if_not_installed("brms")
+  library(brms)
+  void <- capture.output(
+    mod <- brm(am ~ hp + mpg, family = bernoulli, data = mtcars,
+               chains = 2, iter = 1000, seed = 1024, silent = 2)
+  )
+  x <- get_predicted(mod, predict = "link")
+  y <- get_predicted(mod, predict = "expectation")
+  z <- get_predicted(mod, predict = NULL, type = "response")
+  expect_equal(round(x[1], 1), -1.4)
+  expect_equal(round(y[1], 1), .2)
+  expect_identical(y, z)
 })


### PR DESCRIPTION
The confidence intervals did not work when `predict=NULL` and `type="response"`