### PR TITLE
add bSpline to patterns in .remove_pattern_from_names

### DIFF
--- a/R/clean_names.R
+++ b/R/clean_names.R
@@ -121,7 +121,7 @@ clean_names.character <- function(x, include_names = FALSE, ...) {
     "pspline", "scale-poly", "poly", "catg", "asis", "matrx", "pol", "strata",
     "strat", "scale", "scored", "interaction", "sqrt", "sin", "cos", "tan",
     "acos", "asin", "atan", "atan2", "exp", "lsp", "rcs", "pb", "lo",
-    "bs", "ns", "mSpline", "t2", "te", "ti", "tt", # need to be fixed first "mmc", "mm",
+    "bs", "ns", "mSpline", "bSpline", "t2", "te", "ti", "tt", # need to be fixed first "mmc", "mm",
     "mi", "mo", "gp", "s", "I"
   )
 


### PR DESCRIPTION
This solves https://github.com/easystats/insight/issues/480: clean_names not work when bSplines (from the package splines2) are used in (g)lm models