### PR TITLE
.is_empty_object should not use is.list()

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -42,8 +42,12 @@
 .is_empty_object <- function(x) {
   if (inherits(x, "data.frame")) {
     x <- as.data.frame(x)
-  }
-  if (is.list(x) && length(x) > 0) {
+    if (nrow(x) > 0 && ncol(x) > 0) {
+      x <- x[!sapply(x, function(i) all(is.na(i)))]
+      x <- stats::na.omit(x) # faster than checking each row and indexing
+    }
+  # a list but not a data.frame
+  } else if (is.list(x) && length(x) > 0) {
     x <- tryCatch(
       {
         .compact_list(x)
@@ -52,16 +56,10 @@
         x
       }
     )
-  }
-  if (inherits(x, "data.frame")) {
-    if (nrow(x) > 0 && ncol(x) > 0) {
-      x <- x[!sapply(x, function(i) all(is.na(i)))]
-      x <- x[!apply(x, 1, function(i) all(is.na(i))), ]
-      # need to check for is.null for R 3.4
-    }
   } else if (!is.null(x)) {
     x <- stats::na.omit(x)
   }
+  # need to check for is.null for R 3.4
   length(x) == 0 || is.null(x) || isTRUE(nrow(x) == 0) || isTRUE(ncol(x) == 0)
 }
 


### PR DESCRIPTION
`.is_object_empty` checks `is.list(x)` and then compacts it if true. The problem is that a `data.frame` is a list, so we compact all data frames by default, which can be very expensive.

This small change can speed things up a bit in some cases, for e.g., with `get_data`

```r
library(lme4)
library(insight)

N <- 1e6
dat <- data.frame(
    x = rnorm(N),
    k = sample(rnorm(50), N, replace = TRUE),
    m = sample(rnorm(10000), N, replace = TRUE))
dat$y <- dat$x + rnorm(dat$k) + rnorm(dat$m) + rnorm(nrow(dat))
mod <- lmer(y ~ x + (1 | k) + (1 | m), data = dat)
```

Old version:

```r
> bench::mark(get_data(mod), max_iterations = 3)
# A tibble: 1 × 13
  expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr>    <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 get_data(mod) 12.5s  12.5s    0.0801     225MB    0.881     1    11      12.5s
```

New version:

```r
> bench::mark(get_data(mod), max_iterations = 3)
# A tibble: 1 × 13
  expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr>    <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 get_data(mod) 4.25s  4.25s     0.236     181MB     2.12     1     9      4.25s
```