### PR TITLE
speed: .is_empty_object

### DIFF
--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -40,11 +40,15 @@
 
 # is object empty?
 .is_empty_object <- function(x) {
+  flag_empty <- FALSE
   if (inherits(x, "data.frame")) {
     x <- as.data.frame(x)
     if (nrow(x) > 0 && ncol(x) > 0) {
-      x <- x[!sapply(x, function(i) all(is.na(i)))]
-      x <- x[!apply(x, 1, function(i) all(is.na(i))), ]
+      x <- x[, !sapply(x, function(i) all(is.na(i))), drop = FALSE]
+      # this is much faster than apply(x, 1, FUN)
+      flag_empty <- all(rowSums(is.na(x)) == ncol(x))
+    } else {
+      flag_empty <- TRUE
     }
   # a list but not a data.frame
   } else if (is.list(x) && length(x) > 0) {
@@ -60,7 +64,11 @@
     x <- stats::na.omit(x)
   }
   # need to check for is.null for R 3.4
-  length(x) == 0 || is.null(x) || isTRUE(nrow(x) == 0) || isTRUE(ncol(x) == 0)
+  isTRUE(flag_empty) ||
+    length(x) == 0 ||
+    is.null(x) ||
+    isTRUE(nrow(x) == 0) ||
+    isTRUE(ncol(x) == 0)
 }
 
 


### PR DESCRIPTION
Follow up on comments from here: https://github.com/easystats/insight/pull/484#

The new flag/indexing strategy improves the speed of `get_data` by 100x in a naive benchmark I just ran:

New:

```
  expression         min   median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc
  <bch:expr>    <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl> <int> <dbl>
1 get_data(mod)   59.3ms   78.6ms      13.8    57.3MB        0     3     0
```


Old:

```
  expression      min median `itr/sec` mem_alloc `gc/sec` n_itr  n_gc total_time
  <bch:expr>    <bch> <bch:>     <dbl> <bch:byt>    <dbl> <int> <dbl>   <bch:tm>
1 get_data(mod) 9.61s  9.61s     0.104     235MB     1.14     1    11      9.61s
```
