### PR TITLE
get_predicted_ci: warning on non-conformable matrices

### DIFF
--- a/R/get_predicted_ci.R
+++ b/R/get_predicted_ci.R
@@ -319,6 +319,11 @@ get_predicted_se <- function(x,
     return(NULL)
   }
 
+  if (ncol(mm) != ncol(vcovmat)) {
+      warning("Could not compute standard errors or confidence intervals because the model and variance-covariance matrices are non-conformable. This can sometimes happen when the `data` used to make predictions fails to include all the levels of a factor variable or all the interaction components.")
+      return(NULL)
+  }
+
   # compute vcov for predictions
   # Next line equivalent to: diag(M V M')
   var_diag <- colSums(t(mm %*% vcovmat) * t(mm))

--- a/R/get_predicted_ci.R
+++ b/R/get_predicted_ci.R
@@ -320,8 +320,21 @@ get_predicted_se <- function(x,
   }
 
   if (ncol(mm) != ncol(vcovmat)) {
-      warning("Could not compute standard errors or confidence intervals because the model and variance-covariance matrices are non-conformable. This can sometimes happen when the `data` used to make predictions fails to include all the levels of a factor variable or all the interaction components.")
+    # last desperate try
+    mm_full <- get_modelmatrix(x)
+    mm <- tryCatch(
+      {
+        mm_full[as.numeric(row.names(get_modelmatrix(x, data = data))), , drop = FALSE]
+      },
+      error = function(e) {
+        NULL
+      }
+    )
+    # still no match?
+    if (isTRUE(ncol(mm) != ncol(vcovmat))) {
+      warning(format_message("Could not compute standard errors or confidence intervals because the model and variance-covariance matrices are non-conformable. This can sometimes happen when the `data` used to make predictions fails to include all the levels of a factor variable or all the interaction components."), call. = FALSE)
       return(NULL)
+    }
   }
 
   # compute vcov for predictions

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -445,7 +445,14 @@ if (.runThisTest &&
         data = ChickWeight)
       newdata <- ChickWeight[ChickWeight$Time %in% 0:10 & ChickWeight$Chick %in% c(1, 40),]
       newdata$Chick[newdata$Chick == "1"] <- NA
-      expect_warning(get_predicted(mod, data = newdata, include_random = FALSE), regexp = "non-conformable")
+      expect_equal(
+        head(as.data.frame(get_predicted(mod, data = newdata, include_random = FALSE))),
+        data.frame(Predicted = c(37.53433, 47.95719, 58.78866, 70.02873, 81.67742, 93.73472),
+                   SE = c(1.68687, 0.82574, 1.52747, 2.56109, 3.61936, 4.76178),
+                   CI_low = c(34.22096, 46.33525, 55.78837, 64.99819, 74.56822, 84.38154),
+                   CI_high = c(40.84771, 49.57913, 61.78894, 75.05927, 88.78662, 103.08789)),
+        tolerance = 1e-3,
+        ignore_attr = TRUE
+      )
   })
-
 }

--- a/tests/testthat/test-lmer.R
+++ b/tests/testthat/test-lmer.R
@@ -438,4 +438,14 @@ if (.runThisTest &&
     expect_equal(class(get_call(m1)), "call")
     expect_equal(class(get_call(m2)), "call")
   })
+
+  test_that("get_predicted_ci: warning when model matrix and varcovmat do not match", {
+      mod <- lmer(
+        weight ~ 1 + Time + I(Time^2) + Diet + Time:Diet + I(Time^2):Diet + (1 + Time + I(Time^2) | Chick),
+        data = ChickWeight)
+      newdata <- ChickWeight[ChickWeight$Time %in% 0:10 & ChickWeight$Chick %in% c(1, 40),]
+      newdata$Chick[newdata$Chick == "1"] <- NA
+      expect_warning(get_predicted(mod, data = newdata, include_random = FALSE), regexp = "non-conformable")
+  })
+
 }


### PR DESCRIPTION

I’m not sure the first problem raised here <https://github.com/easystats/insight/issues/494> can be fixed in `insight`, but this PR raise a slightly more informative warning and avoids a hard stop:

``` r
library(insight)
library(lme4)

mod <- lmer(
weight ~ 1 + Time + I(Time^2) + Diet + Time:Diet + I(Time^2):Diet + (1 + Time + I(Time^2) | Chick),
data = ChickWeight)
newdata <- ChickWeight[ChickWeight$Time %in% 0:10 & ChickWeight$Chick %in% c(1, 40), ]
newdata$Chick[newdata$Chick == "1"] <- NA

get_predicted(mod, data = newdata, include_random = FALSE)
```

    ## Warning in get_predicted_se(x, predictions, data = data, ci_type = ci_type, :
    ## `get_predicted_ci` could not compute standard errors or confidence intervals
    ## because the model and variance covariance matrices are non-conformable. This can
    ## sometimes happen when the `data` used to make predictions fails to include all
    ## the levels of a factor variable or all the interaction components.

    ## Predicted values:
    ## 
    ##  [1]  37.53433  47.95719  58.78866  70.02873  81.67742  93.73472  38.82396
    ##  [8]  50.12421  63.79489  79.83600  98.24754 119.02951
    ## 
    ## NOTE: Confidence intervals, if available, are stored as attributes and can be accessed using `as.data.frame()` on this output.