### PR TITLE
find_formula: fix when arg "correlation" defined outside of lme()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,9 @@
 
 * Fixed issue with `get_datagrid()` for *brms* models with monotonic factors.
 
+* Fixed issue in `find_formula()` when argument `correlation` was defined 
+outside of `lme()` (@etiennebacher).
+
 # insight 0.16.0
 
 ## New functions

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 * Fixed issue with `get_datagrid()` for *brms* models with monotonic factors.
 
 * Fixed issue in `find_formula()` when argument `correlation` was defined 
-outside of `lme()` (@etiennebacher).
+outside of `lme()` (@etiennebacher, #525).
 
 # insight 0.16.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -49,7 +49,7 @@
 * Fixed issue with `get_datagrid()` for *brms* models with monotonic factors.
 
 * Fixed issue in `find_formula()` when argument `correlation` was defined 
-outside of `lme()` (@etiennebacher, #525).
+outside of `lme()` and `gls()` (@etiennebacher, #525).
 
 # insight 0.16.0
 

--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -516,7 +516,7 @@ find_formula.gls <- function(x, verbose = TRUE, ...) {
   }
   if (is.symbol(f_corr)) {
     f_corr <- paste("~", .safe_deparse(f_corr))
-  } else if (class(f_corr) != "formula") {
+  } else if (!inherits(f_corr, "formula")) {
     f_corr <- f_corr$form
   }
 
@@ -1181,7 +1181,7 @@ find_formula.lme <- function(x, verbose = TRUE, ...) {
   ## TODO this is an intermediate fix to return the correlation variables from lme-objects
   fcorr <- x$call$correlation
   if (!is.null(fcorr)) {
-    if (class(fcorr) == "name") {
+    if (inherits(fcorr, "name")) {
       fc <- attributes(eval(fcorr))$formula
     } else {
       fc <- parse(text = .safe_deparse(x$call$correlation))[[1]]$form

--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -506,10 +506,10 @@ find_formula.gls <- function(x, verbose = TRUE, ...) {
   ## TODO this is an intermediate fix to return the correlation variables from gls-objects
   fcorr <- x$call$correlation
   if (!is.null(fcorr)) {
-    if (class(fcorr) == "name") {
+    if (inherits(fcorr, "name")) {
       f_corr <- attributes(eval(fcorr))$formula
     } else {
-      f_corr <- parse(text = .safe_deparse(x$call$correlation))[[1]]
+      f_corr <- parse(text = .safe_deparse(fcorr))[[1]]
     }
   } else {
     f_corr <- NULL
@@ -1184,7 +1184,7 @@ find_formula.lme <- function(x, verbose = TRUE, ...) {
     if (inherits(fcorr, "name")) {
       fc <- attributes(eval(fcorr))$formula
     } else {
-      fc <- parse(text = .safe_deparse(x$call$correlation))[[1]]$form
+      fc <- parse(text = .safe_deparse(fcorr))[[1]]$form
     }
   } else {
     fc <- NULL

--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -506,13 +506,17 @@ find_formula.gls <- function(x, verbose = TRUE, ...) {
   ## TODO this is an intermediate fix to return the correlation variables from gls-objects
   fcorr <- x$call$correlation
   if (!is.null(fcorr)) {
-    f_corr <- parse(text = .safe_deparse(x$call$correlation))[[1]]
+    if (class(fcorr) == "name") {
+      f_corr <- attributes(eval(fcorr))$formula
+    } else {
+      f_corr <- parse(text = .safe_deparse(x$call$correlation))[[1]]
+    }
   } else {
     f_corr <- NULL
   }
   if (is.symbol(f_corr)) {
     f_corr <- paste("~", .safe_deparse(f_corr))
-  } else {
+  } else if (class(f_corr) != "formula") {
     f_corr <- f_corr$form
   }
 

--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -1177,7 +1177,11 @@ find_formula.lme <- function(x, verbose = TRUE, ...) {
   ## TODO this is an intermediate fix to return the correlation variables from lme-objects
   fcorr <- x$call$correlation
   if (!is.null(fcorr)) {
-    fc <- parse(text = .safe_deparse(x$call$correlation))[[1]]$form
+    if (class(fcorr) == "name") {
+      fc <- attributes(eval(fcorr))$formula
+    } else {
+      fc <- parse(text = .safe_deparse(x$call$correlation))[[1]]$form
+    }
   } else {
     fc <- NULL
   }

--- a/tests/testthat/test-gls.R
+++ b/tests/testthat/test-gls.R
@@ -8,7 +8,7 @@ if (requiet("testthat") &&
   )
 
   cr <- corAR1(form = ~ 1 | Mare)
-  m2 <- lme(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
+  m2 <- gls(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
              correlation = cr)
 
   test_that("model_info", {

--- a/tests/testthat/test-gls.R
+++ b/tests/testthat/test-gls.R
@@ -7,6 +7,10 @@ if (requiet("testthat") &&
     correlation = corAR1(form = ~ 1 | Mare)
   )
 
+  cr <- corAR1(form = ~ 1 | Mare)
+  m2 <- lme(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
+             correlation = cr)
+
   test_that("model_info", {
     expect_true(model_info(m1)$is_linear)
   })
@@ -37,6 +41,14 @@ if (requiet("testthat") &&
     expect_length(find_formula(m1), 2)
     expect_equal(
       find_formula(m1),
+      list(
+        conditional = as.formula("follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time)"),
+        correlation = as.formula("~1 | Mare")
+      ),
+      ignore_attr = TRUE
+    )
+    expect_equal(
+      find_formula(m2),
       list(
         conditional = as.formula("follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time)"),
         correlation = as.formula("~1 | Mare")

--- a/tests/testthat/test-gls.R
+++ b/tests/testthat/test-gls.R
@@ -7,7 +7,7 @@ if (requiet("testthat") &&
     correlation = corAR1(form = ~ 1 | Mare)
   )
 
-  cr <- corAR1(form = ~ 1 | Mare)
+  cr <<- corAR1(form = ~ 1 | Mare)
   m2 <- gls(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
              correlation = cr)
 

--- a/tests/testthat/test-lme.R
+++ b/tests/testthat/test-lme.R
@@ -25,6 +25,10 @@ if (requiet("testthat") &&
     data = sleepstudy
   )
 
+  # from easystats/insight/482
+  cr <- corAR1(form = ~ 1 | Mare)
+  m4 <- lme(follicles ~ Time, Ovary, correlation = cr)
+
   test_that("nested_varCorr", {
     skip_on_cran()
 
@@ -111,6 +115,15 @@ if (requiet("testthat") &&
       list(
         conditional = as.formula("distance ~ age + Sex"),
         random = as.formula("~1")
+      ),
+      ignore_attr = TRUE
+    )
+    expect_length(find_formula(m4), 2)
+    expect_equal(
+      find_formula(m4),
+      list(
+        conditional = as.formula("follicles ~ Time"),
+        correlation = as.formula("~1 | Mare")
       ),
       ignore_attr = TRUE
     )


### PR DESCRIPTION
Close #482 

```r
library(nlme)
cr <- corAR1(form = ~ 1 | Mare)
fm1 <- lme(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
           correlation = cr)
insight::find_formula(fm1)

$conditional
follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time)
<environment: 0x0000024c7b2e5e28>

$correlation
~1 | Mare

attr(,"class")
[1] "insight_formula" "list"           

fm2 <- lme(follicles ~ sin(2*pi*Time) + cos(2*pi*Time), Ovary,
           correlation = corAR1(form = ~ 1 | Mare))
insight::find_formula(fm2)

$conditional
follicles ~ sin(2 * pi * Time) + cos(2 * pi * Time)
<environment: 0x0000024c6fa4b718>

$correlation
~1 | Mare
<environment: 0x0000024c6fa4b718>

attr(,"class")
[1] "insight_formula" "list" 
```