### PR TITLE
WIP: get_varcov(): vcov and vcov_args arguments

### DIFF
--- a/R/get_predicted_se.R
+++ b/R/get_predicted_se.R
@@ -15,7 +15,7 @@ get_predicted_se <- function(x,
 
   vcovmat <- get_varcov(
     x,
-    vcov_fun = vcov,
+    vcov = vcov,
     vcov_args = vcov_args,
     ...
   )

--- a/R/get_predicted_se.R
+++ b/R/get_predicted_se.R
@@ -13,7 +13,7 @@ get_predicted_se <- function(x,
   # the diagonal of this matrix represent the standard errors of the predictions,
   # which are then multiplied by 1.96 for the confidence intervals.
 
-  vcovmat <- .get_predicted_ci_vcov(
+  vcovmat <- .get_varcov_sandwich(
     x,
     vcov_fun = vcov,
     vcov_args = vcov_args,
@@ -81,133 +81,12 @@ get_predicted_se <- function(x,
 
 
 
-# Get Variance-covariance Matrix ---------------------------------------------------
-
-.get_predicted_ci_vcov <- function(x,
-                                   vcov_fun = NULL,
-                                   vcov_args = NULL,
-                                   verbose = TRUE,
-                                   ...) {
-  dots <- list(...)
-
-  # deprecated
-  if (isTRUE(verbose) && "vcov_type" %in% names(dots)) {
-    warning(format_message("The `vcov_type` argument is superseded by the `vcov_args` argument."), call. = FALSE)
-  }
-  if (isTRUE(verbose) && "robust" %in% names(dots)) {
-    warning(format_message("The `robust` argument is superseded by the `vcov` argument."), call. = FALSE)
-  }
-
-  if (is.null(vcov_args)) {
-    vcov_args <- list()
-  }
-
-  # deprecated: `vcov_estimation`
-  if (is.null(vcov_fun) && "vcov_estimation" %in% names(dots)) {
-    vcov_fun <- dots[["vcov_estimation"]]
-  }
-
-  # deprecated: `robust`
-  if (isTRUE(dots[["robust"]]) && is.null(vcov_fun)) {
-    dots[["robust"]] <- NULL
-    vcov_fun <- "HC3"
-  }
-
-  # deprecated: `vcov_type`
-  if ("vcov_type" %in% names(dots)) {
-    if (!"type" %in% names(vcov_args)) {
-      vcov_args[["type"]] <- dots[["vcov_type"]]
-    }
-  }
-
-  # vcov_fun is a matrix
-  if (is.matrix(vcov_fun)) {
-    return(vcov_fun)
-  }
-
-  # vcov_fun is a function
-  if (is.function(vcov_fun)) {
-    if (is.null(vcov_args) || !is.list(vcov_args)) {
-      args <- list(x)
-    } else {
-      args <- c(list(x), vcov_args)
-    }
-    .vcov <- do.call("vcov_fun", args)
-    return(.vcov)
-  }
-
-  # type shortcuts: overwrite only if not supplied explicitly by the user
-  if (!"type" %in% names(vcov_args)) {
-    if (isTRUE(vcov_fun %in% c(
-      "HC0", "HC1", "HC2", "HC3", "HC4", "HC4m", "HC5",
-      "CR0", "CR1", "CR1p", "CR1S", "CR2", "CR3", "xy",
-      "residual", "wild", "mammen", "webb"
-    ))) {
-      vcov_args[["type"]] <- vcov_fun
-    }
-  }
-
-  # default vcov matrix
-  if (is.null(vcov_fun)) {
-    .vcov <- get_varcov(x, ...)
-    return(.vcov)
-  }
-
-  if (!grepl("^(vcov|kernHAC|NeweyWest)", vcov_fun)) {
-    vcov_fun <- switch(vcov_fun,
-      "HC0" = ,
-      "HC1" = ,
-      "HC2" = ,
-      "HC3" = ,
-      "HC4" = ,
-      "HC4m" = ,
-      "HC5" = ,
-      "HC" = "vcovHC",
-      "CR0" = ,
-      "CR1" = ,
-      "CR1p" = ,
-      "CR1S" = ,
-      "CR2" = ,
-      "CR3" = ,
-      "CR" = "vcovCR",
-      "xy" = ,
-      "residual" = ,
-      "wild" = ,
-      "mammen" = ,
-      "webb" = ,
-      "BS" = "vcovBS",
-      "OPG" = "vcovOPG",
-      "HAC" = "vcovHAC",
-      "PC" = "vcovPC",
-      "CL" = "vcovCL",
-      "PL" = "vcovPL"
-    )
-  }
-
-  # check if required package is available
-  if (vcov_fun == "vcovCR") {
-    check_if_installed("clubSandwich", reason = "to get cluster-robust standard errors")
-    fun <- get(vcov_fun, asNamespace("clubSandwich"))
-  } else {
-    check_if_installed("sandwich", reason = "to get robust standard errors")
-    fun <- try(get(vcov_fun, asNamespace("sandwich")), silent = TRUE)
-    if (!is.function(fun)) {
-      stop(sprintf("`%s` is not a function exported by the `sandwich` package.", vcov_fun))
-    }
-  }
-
-  # extract variance-covariance matrix
-  .vcov <- do.call(fun, c(list(x), vcov_args))
-
-  .vcov
-}
-
 
 # Get Model matrix ------------------------------------------------------------
 
 .get_predicted_ci_modelmatrix <- function(x, data = NULL, vcovmat = NULL, ...) {
   resp <- find_response(x)
-  if (is.null(vcovmat)) vcovmat <- .get_predicted_ci_vcov(x, ...)
+  if (is.null(vcovmat)) vcovmat <- .get_varcov_sandwich(x, ...)
 
 
   if (is.null(data)) {

--- a/R/get_predicted_se.R
+++ b/R/get_predicted_se.R
@@ -13,7 +13,7 @@ get_predicted_se <- function(x,
   # the diagonal of this matrix represent the standard errors of the predictions,
   # which are then multiplied by 1.96 for the confidence intervals.
 
-  vcovmat <- .get_varcov_sandwich(
+  vcovmat <- get_varcov(
     x,
     vcov_fun = vcov,
     vcov_args = vcov_args,
@@ -86,7 +86,7 @@ get_predicted_se <- function(x,
 
 .get_predicted_ci_modelmatrix <- function(x, data = NULL, vcovmat = NULL, ...) {
   resp <- find_response(x)
-  if (is.null(vcovmat)) vcovmat <- .get_varcov_sandwich(x, ...)
+  if (is.null(vcovmat)) vcovmat <- get_varcov(x, ...)
 
 
   if (is.null(data)) {

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -40,9 +40,12 @@ get_varcov <- function(x, ...) {
   dots <- list(...)
   if ("vcov" %in% names(dots) && !is.null(dots$vcov)) {
     # list of supported classes from Zeileis et al. (2020) JSS
-    supported <- c("lm", "glm", "betareg", "clm", "coxph", "survreg", "crch",
-                   "hurdle", "zeroinfl", "pscl", "countreg", "mlogit", "polr",
-                   "rlm", "fixest")
+    supported_sandwich <- c("lm", "glm", "betareg", "clm", "coxph", "survreg",
+                            "crch", "hurdle", "zeroinfl", "pscl", "countreg",
+                            "mlogit", "polr", "rlm", "fixest")
+    supported_clubSandwich <- c("glm", "gls", "ivreg", "lm", "lme", "lmerMod",
+                                "mlm", "plm", "rma.mv", "rma.uni", "robu")
+    supported <- c(supported_sandwich, supported_clubSandwich)
     if (!any(supported %in% class(x))) {
       msg <- sprintf("Models of class `%s` may not be supported by the `sandwich` or `clubSandwich` packages. In such cases, `get_varcov()` ignores the `vcov` argument and tries to return the model object's default variance-covariance matrix.", class(x)[1])
       warning(format_message(msg), call. = FALSE)
@@ -402,7 +405,8 @@ get_varcov.MixMod <- function(x,
 
   if (effects == "random") {
     vc <- random_vc
-  } else {
+  } else 
+    {
     vc <- switch(component,
       "conditional" = stats::vcov(x, parm = "fixed-effects", sandwich = robust),
       "zero_inflated" = ,

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -130,7 +130,6 @@ get_varcov.betareg <- function(x,
 }
 
 
-#' @rdname get_varcov
 #' @export
 get_varcov.DirichletRegModel <- function(x,
                                          component = c("conditional", "precision", "all"),
@@ -307,7 +306,6 @@ get_varcov.truncreg <- function(x, component = c("conditional", "all"), ...) {
 }
 
 
-#' @rdname get_varcov
 #' @export
 get_varcov.gamlss <- function(x, component = c("conditional", "all"), ...) {
   .check_get_varcov_dots(x, ...)
@@ -373,7 +371,6 @@ get_varcov.zeroinfl <- get_varcov.hurdle
 #' @export
 get_varcov.zerocount <- get_varcov.hurdle
 
-#' @rdname get_varcov
 #' @export
 get_varcov.zcpglm <- function(x,
                               component = c("conditional", "zero_inflated", "zi", "all"),

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -57,7 +57,8 @@ get_varcov.default <- function(x,
     if (is.null(vcov)) {
       vcov <- "HC3"
     }
-    warning("The `robust` argument is deprecated. Please use `vcov` instead.")
+    warning("The `robust` argument is deprecated. Please use `vcov` instead.",
+            call. = FALSE)
   }
 
   if (is.null(vcov)) {
@@ -958,6 +959,6 @@ get_varcov.LORgee <- get_varcov.gee
   # supported by a method, and thus that it will be ignored.
   if ("vcov" %in% names(dots)) {
     msg <- sprintf("The `vcov` argument of the `insight::get_varcov()` function is not yet supported for models of class `%s`.", paste(class(x), collapse = "/"))
-    warning(format_message(msg))
+    warning(format_message(msg), call. = FALSE)
   }
 }

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -36,21 +36,6 @@
 #' get_varcov(m)
 #' @export
 get_varcov <- function(x, ...) {
-  # not all model types are supported by `sandwich` and `clubSandwich`
-  dots <- list(...)
-  if ("vcov" %in% names(dots) && !is.null(dots$vcov)) {
-    # list of supported classes from Zeileis et al. (2020) JSS
-    supported_sandwich <- c("lm", "glm", "betareg", "clm", "coxph", "survreg",
-                            "crch", "hurdle", "zeroinfl", "pscl", "countreg",
-                            "mlogit", "polr", "rlm", "fixest")
-    supported_clubSandwich <- c("glm", "gls", "ivreg", "lm", "lme", "lmerMod",
-                                "mlm", "plm", "rma.mv", "rma.uni", "robu")
-    supported <- c(supported_sandwich, supported_clubSandwich)
-    if (!any(supported %in% class(x))) {
-      msg <- sprintf("Models of class `%s` may not be supported by the `sandwich` or `clubSandwich` packages. In such cases, `get_varcov()` ignores the `vcov` argument and tries to return the model object's default variance-covariance matrix.", class(x)[1])
-      warning(format_message(msg), call. = FALSE)
-    }
-  }
   UseMethod("get_varcov")
 }
 
@@ -65,7 +50,7 @@ get_varcov.default <- function(x,
                                vcov = NULL,
                                vcov_args = NULL,
                                ...) {
-
+  .check_get_varcov_dots(x, ...)
   dots <- list(...)
   if ("robust" %in% names(dots)) {
     # default robust covariance
@@ -98,6 +83,7 @@ get_varcov.HLfit <- get_varcov.default
 
 #' @export
 get_varcov.mlm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   if (!is.null(x$weights)) {
     s <- summary(x)[[1L]]
     .get_weighted_varcov(x, s$cov.unscaled)
@@ -117,6 +103,8 @@ get_varcov.betareg <- function(x,
                                component = c("conditional", "precision", "all"),
                                verbose = TRUE,
                                ...) {
+
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
 
   vc <- switch(component,
@@ -134,6 +122,7 @@ get_varcov.DirichletRegModel <- function(x,
                                          component = c("conditional", "precision", "all"),
                                          verbose = TRUE,
                                          ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   if (x$parametrization == "common") {
     vc <- stats::vcov(x)
@@ -159,6 +148,7 @@ get_varcov.DirichletRegModel <- function(x,
 get_varcov.clm2 <- function(x,
                             component = c("all", "conditional", "scale"),
                             ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
 
   n_intercepts <- length(x$xi)
@@ -193,6 +183,7 @@ get_varcov.clmm2 <- get_varcov.clm2
 get_varcov.glmx <- function(x,
                             component = c("all", "conditional", "extra"),
                             ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(object = x)
 
@@ -206,6 +197,7 @@ get_varcov.glmx <- function(x,
 
 #' @export
 get_varcov.pgmm <- function(x, component = c("conditional", "all"), ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(x)
 
@@ -221,6 +213,7 @@ get_varcov.pgmm <- function(x, component = c("conditional", "all"), ...) {
 get_varcov.selection <- function(x,
                                  component = c("all", "selection", "outcome", "auxiliary"),
                                  ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(object = x)
 
@@ -241,6 +234,7 @@ get_varcov.selection <- function(x,
 get_varcov.mvord <- function(x,
                              component = c("all", "conditional", "thresholds", "correlation"),
                              ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(x)
 
@@ -260,6 +254,7 @@ get_varcov.mvord <- function(x,
 get_varcov.mjoint <- function(x,
                               component = c("all", "conditional", "survival"),
                               ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(x)
 
@@ -271,6 +266,7 @@ get_varcov.mjoint <- function(x,
 
 #' @export
 get_varcov.mhurdle <- function(x, component = c("all", "conditional", "zi", "zero_inflated", "infrequent_purchase", "ip", "auxiliary"), ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(x)
 
@@ -286,6 +282,7 @@ get_varcov.mhurdle <- function(x, component = c("all", "conditional", "zi", "zer
 #' @rdname get_varcov
 #' @export
 get_varcov.truncreg <- function(x, component = c("conditional", "all"), ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- stats::vcov(x)
 
@@ -299,6 +296,7 @@ get_varcov.truncreg <- function(x, component = c("conditional", "all"), ...) {
 #' @rdname get_varcov
 #' @export
 get_varcov.gamlss <- function(x, component = c("conditional", "all"), ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   vc <- suppressWarnings(stats::vcov(x))
 
@@ -322,6 +320,7 @@ get_varcov.gamlss <- function(x, component = c("conditional", "all"), ...) {
 get_varcov.hurdle <- function(x,
                               component = c("conditional", "zero_inflated", "zi", "all"),
                               ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
 
   vc <- switch(component,
@@ -344,6 +343,7 @@ get_varcov.zerocount <- get_varcov.hurdle
 get_varcov.zcpglm <- function(x,
                               component = c("conditional", "zero_inflated", "zi", "all"),
                               ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
 
   # installed?
@@ -372,6 +372,7 @@ get_varcov.zcpglm <- function(x,
 get_varcov.glmmTMB <- function(x,
                                component = c("conditional", "zero_inflated", "zi", "dispersion", "all"),
                                ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
 
   vc <- switch(component,
@@ -392,6 +393,7 @@ get_varcov.MixMod <- function(x,
                               component = c("conditional", "zero_inflated", "zi", "dispersion", "auxiliary", "all"),
                               verbose = TRUE,
                               ...) {
+  .check_get_varcov_dots(x, ...)
 
   # backward compatibility. there used to be a `robust` argument in this
   # method, but we have now moved to `vcov` and `vcov_args`. Also, `robust`
@@ -441,6 +443,7 @@ get_varcov.MixMod <- function(x,
 #' @rdname get_varcov
 #' @export
 get_varcov.brmsfit <- function(x, component = "conditional", ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component, choices = c("all", .all_elements()))
   params <- find_parameters(x, effects = "fixed", component = component, flatten = TRUE)
   params <- gsub("^b_", "", params)
@@ -458,6 +461,7 @@ get_varcov.brmsfit <- function(x, component = "conditional", ...) {
 get_varcov.betamfx <- function(x,
                                component = c("conditional", "precision", "all"),
                                ...) {
+  .check_get_varcov_dots(x, ...)
   component <- match.arg(component)
   get_varcov.betareg(x$fit, component = component, ...)
 }
@@ -467,6 +471,7 @@ get_varcov.betaor <- get_varcov.betamfx
 
 #' @export
 get_varcov.logitmfx <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   get_varcov(x$fit, ...)
 }
 
@@ -497,6 +502,7 @@ get_varcov.model_fit <- get_varcov.logitmfx
 
 #' @export
 get_varcov.merModList <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   warning("Can't access variance-covariance matrix for 'merModList' objects.", call. = FALSE)
   return(NULL)
 }
@@ -504,6 +510,7 @@ get_varcov.merModList <- function(x, ...) {
 
 #' @export
 get_varcov.mediate <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   warning("Can't access variance-covariance matrix for 'mediate' objects.", call. = FALSE)
   return(NULL)
 }
@@ -512,6 +519,7 @@ get_varcov.mediate <- function(x, ...) {
 #' @rdname get_varcov
 #' @export
 get_varcov.aov <- function(x, complete = FALSE, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- suppressWarnings(stats::vcov(x, complete = complete))
   .process_vcov(vc)
 }
@@ -519,12 +527,14 @@ get_varcov.aov <- function(x, complete = FALSE, ...) {
 
 #' @export
 get_varcov.ivFixed <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   .process_vcov(x$vcov)
 }
 
 
 #' @export
 get_varcov.averaging <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   if (is.null(attributes(x)$modelList)) {
     warning("Can't calculate covariance matrix. Please use 'fit = TRUE' in 'model.avg()'.", call. = FALSE)
   } else {
@@ -535,6 +545,7 @@ get_varcov.averaging <- function(x, ...) {
 
 #' @export
 get_varcov.robmixglm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   params <- find_parameters(x, flatten = TRUE)
   np <- length(params)
   vc <- x$fit@vcov[1:np, 1:np, drop = FALSE]
@@ -546,6 +557,7 @@ get_varcov.robmixglm <- function(x, ...) {
 
 #' @export
 get_varcov.Rchoice <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- stats::vcov(x)
   params <- find_parameters(x, flatten = TRUE)
   dimnames(vc) <- list(params, params)
@@ -555,6 +567,7 @@ get_varcov.Rchoice <- function(x, ...) {
 
 #' @export
 get_varcov.rq <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   s <- summary(x, covariance = TRUE)
   vc <- as.matrix(s$cov)
 
@@ -573,6 +586,7 @@ get_varcov.rq <- function(x, ...) {
 
 #' @export
 get_varcov.crr <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- as.matrix(x$var)
   params <- find_parameters(x, flatten = TRUE)
   dimnames(vc) <- list(params, params)
@@ -582,6 +596,7 @@ get_varcov.crr <- function(x, ...) {
 
 #' @export
 get_varcov.crq <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   sc <- summary(x, covariance = TRUE)
   preds <- find_parameters(x, flatten = TRUE)
 
@@ -619,6 +634,7 @@ get_varcov.rqs <- get_varcov.crq
 
 #' @export
 get_varcov.flexsurvreg <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   pars <- find_parameters(x, flatten = TRUE)
   vc <- as.matrix(stats::vcov(x))[pars, pars, drop = FALSE]
   .process_vcov(vc)
@@ -627,12 +643,14 @@ get_varcov.flexsurvreg <- function(x, ...) {
 
 #' @export
 get_varcov.afex_aov <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   get_varcov(x$lm, ...)
 }
 
 
 #' @export
 get_varcov.mixed <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- as.matrix(stats::vcov(x$full_model))
   .process_vcov(vc)
 }
@@ -640,6 +658,7 @@ get_varcov.mixed <- function(x, ...) {
 
 #' @export
 get_varcov.cpglmm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- as.matrix(x@vcov)
   .process_vcov(vc)
 }
@@ -651,6 +670,7 @@ get_varcov.cpglm <- get_varcov.cpglmm
 
 #' @export
 get_varcov.cglm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- as.matrix(x$var)
   .process_vcov(vc)
 }
@@ -659,6 +679,7 @@ get_varcov.cglm <- function(x, ...) {
 
 #' @export
 get_varcov.mle2 <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- as.matrix(x@vcov)
   .process_vcov(vc)
 }
@@ -672,6 +693,7 @@ get_varcov.mle <- get_varcov.mle2
 #' @rdname get_varcov
 #' @export
 get_varcov.mixor <- function(x, effects = c("all", "fixed", "random"), ...) {
+  .check_get_varcov_dots(x, ...)
   effects <- match.arg(effects)
   params <- find_parameters(x, effects = effects, flatten = TRUE)
   vc <- as.matrix(stats::vcov(x))[params, params, drop = FALSE]
@@ -685,6 +707,7 @@ get_varcov.glmm <- get_varcov.mixor
 
 #' @export
 get_varcov.gamm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- stats::vcov(x$gam)
   .process_vcov(vc)
 }
@@ -692,6 +715,7 @@ get_varcov.gamm <- function(x, ...) {
 
 #' @export
 get_varcov.lqmm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   sc <- summary(x, covariance = TRUE)
   np <- length(find_parameters(x, flatten = TRUE))
 
@@ -721,6 +745,7 @@ get_varcov.lqm <- get_varcov.lqmm
 
 #' @export
 get_varcov.list <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   if ("gam" %in% names(x)) {
     vc <- stats::vcov(x$gam)
     .process_vcov(vc)
@@ -730,6 +755,7 @@ get_varcov.list <- function(x, ...) {
 
 #' @export
 get_varcov.BBmm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$fixed.vcov
   .process_vcov(vc)
 }
@@ -737,6 +763,7 @@ get_varcov.BBmm <- function(x, ...) {
 
 #' @export
 get_varcov.BBreg <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$vcov
   .process_vcov(vc)
 }
@@ -744,6 +771,7 @@ get_varcov.BBreg <- function(x, ...) {
 
 #' @export
 get_varcov.feis <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$vcov
   .process_vcov(vc)
 }
@@ -751,6 +779,7 @@ get_varcov.feis <- function(x, ...) {
 
 #' @export
 get_varcov.glimML <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   # installed?
   check_if_installed("aod")
 
@@ -762,6 +791,7 @@ get_varcov.glimML <- function(x, ...) {
 
 #' @export
 get_varcov.vglm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   # installed?
   check_if_installed("VGAM")
   vc <- VGAM::vcov(x)
@@ -775,6 +805,7 @@ get_varcov.vgam <- get_varcov.vglm
 
 #' @export
 get_varcov.geeglm <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- summary(x)$cov.unscaled
   .process_vcov(vc)
 }
@@ -782,6 +813,7 @@ get_varcov.geeglm <- function(x, ...) {
 
 #' @export
 get_varcov.tobit <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   coef_names <- find_parameters(x, flatten = TRUE)
   vc <- stats::vcov(x)[coef_names, coef_names, drop = FALSE]
   .process_vcov(vc)
@@ -790,6 +822,7 @@ get_varcov.tobit <- function(x, ...) {
 
 #' @export
 get_varcov.lmRob <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$cov
   .process_vcov(vc)
 }
@@ -802,6 +835,7 @@ get_varcov.glmRob <- get_varcov.lmRob
 
 #' @export
 get_varcov.coxr <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$var
   .process_vcov(vc)
 }
@@ -809,6 +843,7 @@ get_varcov.coxr <- function(x, ...) {
 
 #' @export
 get_varcov.gee <- function(x, ...) {
+  .check_get_varcov_dots(x, ...)
   vc <- x$naive.variance
   .process_vcov(vc)
 }
@@ -914,5 +949,15 @@ get_varcov.LORgee <- get_varcov.gee
       }
       return(crossprod(x, w %*% x))
     }
+  }
+}
+
+.check_get_varcov_dots <- function(x, ...) {
+  dots <- list(...)
+  # if `vcov` is in ..., it means that the argument is not explicitly
+  # supported by a method, and thus that it will be ignored.
+  if ("vcov" %in% names(dots)) {
+    msg <- sprintf("The `vcov` argument of the `insight::get_varcov()` function is not yet supported for models of class `%s`.", paste(class(x), collapse = "/"))
+    warning(format_message(msg))
   }
 }

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -48,7 +48,7 @@
 #'   mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
 #'   get_varcov(
 #'     mod,
-#'     component = "zero_inflated",
+#'     component = "conditional",
 #'     vcov = "BS",
 #'     vcov_args = list(R = 50)
 #'   )

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -36,6 +36,18 @@
 #' get_varcov(m)
 #' @export
 get_varcov <- function(x, ...) {
+  # not all model types are supported by `sandwich` and `clubSandwich`
+  dots <- list(...)
+  if ("vcov" %in% names(dots) && !is.null(dots$vcov)) {
+    # list of supported classes from Zeileis et al. (2020) JSS
+    supported <- c("lm", "glm", "betareg", "clm", "coxph", "survreg", "crch",
+                   "hurdle", "zeroinfl", "pscl", "countreg", "mlogit", "polr",
+                   "rlm", "fixest")
+    if (!any(supported %in% class(x))) {
+      msg <- sprintf("Models of class `%s` may not be supported by the `sandwich` or `clubSandwich` packages. In such cases, `get_varcov()` ignores the `vcov` argument and tries to return the model object's default variance-covariance matrix.", class(mod)[1])
+      warning(format_message(msg), call. = FALSE)
+    }
+  }
   UseMethod("get_varcov")
 }
 

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -21,8 +21,7 @@
 #'   applies to models of class `mixor`.
 #' @param complete Logical, if `TRUE`, for `aov`, returns the full
 #'   variance-covariance matrix.
-#' @param robust Logical, if `TRUE`, returns a robust variance-covariance matrix
-#'   using sandwich estimation.
+#' @inheritParams get_predicted_ci
 #' @param verbose Toggle warnings.
 #' @param ... Currently not used.
 #'
@@ -46,8 +45,30 @@ get_varcov <- function(x, ...) {
 
 #' @rdname get_varcov
 #' @export
-get_varcov.default <- function(x, verbose = TRUE, ...) {
-  vc <- suppressWarnings(stats::vcov(x))
+get_varcov.default <- function(x,
+                               verbose = TRUE,
+                               vcov = NULL,
+                               vcov_args = NULL,
+                               ...) {
+
+  dots <- list(...)
+  if ("robust" %in% names(dots)) {
+    # default robust covariance
+    if (is.null(vcov)) {
+      vcov <- "HC3"
+    }
+    warning("The `robust` argument is deprecated. Please use `vcov` instead.")
+  }
+
+  if (is.null(vcov)) {
+    vc <- suppressWarnings(stats::vcov(x))
+  } else {
+    vc <- .get_varcov_sandwich(x,
+                               vcov_fun = vcov,
+                               vcov_args = vcov_args,
+                               verbose = FALSE,
+                               ...)
+  }
   .process_vcov(vc, verbose)
 }
 

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -34,6 +34,25 @@
 #' data(mtcars)
 #' m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 #' get_varcov(m)
+#'
+#' # vcov of zero-inflation component from hurdle-model
+#' if (require("pscl")) {
+#'   data("bioChemists", package = "pscl")
+#'   mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+#'   get_varcov(mod, component = "zero_inflated")
+#' }
+#'
+#' # robust vcov of, count component from hurdle-model
+#' if (require("pscl") && require("sandwich")) {
+#'   data("bioChemists", package = "pscl")
+#'   mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+#'   get_varcov(
+#'     mod,
+#'     component = "zero_inflated",
+#'     vcov = "BS",
+#'     vcov_args = list(R = 50)
+#'   )
+#' }
 #' @export
 get_varcov <- function(x, ...) {
   UseMethod("get_varcov")

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -387,9 +387,14 @@ get_varcov.glmmTMB <- function(x,
 get_varcov.MixMod <- function(x,
                               effects = c("fixed", "random"),
                               component = c("conditional", "zero_inflated", "zi", "dispersion", "auxiliary", "all"),
-                              robust = FALSE,
                               verbose = TRUE,
                               ...) {
+
+  # backward compatibility. there used to be a `robust` argument in this
+  # method, but we have now moved to `vcov` and `vcov_args`. Also, `robust`
+  # does not seem to be a documented argument for the `MixMod` class.
+  robust <- isTRUE(list(...)[["robust"]])
+
   component <- match.arg(component)
   effects <- match.arg(effects)
 

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -423,8 +423,7 @@ get_varcov.MixMod <- function(x,
 
   if (effects == "random") {
     vc <- random_vc
-  } else 
-    {
+  } else {
     vc <- switch(component,
       "conditional" = stats::vcov(x, parm = "fixed-effects", sandwich = robust),
       "zero_inflated" = ,

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -50,8 +50,15 @@ get_varcov.default <- function(x,
                                vcov = NULL,
                                vcov_args = NULL,
                                ...) {
+
   .check_get_varcov_dots(x, ...)
   dots <- list(...)
+
+  # backward compatibility for `get_predicted_se()`
+  if (is.null(vcov) && "vcov_estimation" %in% names(dots)) {
+    vcov <- dots[["vcov_estimation"]]
+  }
+
   if ("robust" %in% names(dots)) {
     # default robust covariance
     if (is.null(vcov)) {

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -44,7 +44,7 @@ get_varcov <- function(x, ...) {
                    "hurdle", "zeroinfl", "pscl", "countreg", "mlogit", "polr",
                    "rlm", "fixest")
     if (!any(supported %in% class(x))) {
-      msg <- sprintf("Models of class `%s` may not be supported by the `sandwich` or `clubSandwich` packages. In such cases, `get_varcov()` ignores the `vcov` argument and tries to return the model object's default variance-covariance matrix.", class(mod)[1])
+      msg <- sprintf("Models of class `%s` may not be supported by the `sandwich` or `clubSandwich` packages. In such cases, `get_varcov()` ignores the `vcov` argument and tries to return the model object's default variance-covariance matrix.", class(x)[1])
       warning(format_message(msg), call. = FALSE)
     }
   }

--- a/R/get_varcov_sandwich.R
+++ b/R/get_varcov_sandwich.R
@@ -122,7 +122,7 @@
 
   # extract variance-covariance matrix
   if (!inherits(.vcov, "matrix")) {
-    msg <- sprintf("Unable to extract a variance-covariance matrix for model object of class `%s`. Different values of the `vcov` argument trigger calls to the `sandwich` or `clubSandwich` packages in order to extract the matrix (see `?insight::get_varcov`). Your model may not be supported by one or both of those packages.", class(x)[1])
+    msg <- sprintf("Unable to extract a variance-covariance matrix for model object of class `%s`. Different values of the `vcov` argument trigger calls to the `sandwich` or `clubSandwich` packages in order to extract the matrix (see `?insight::get_varcov`). Your model or the requested estimation type may not be supported by one or both of those packages.", class(x)[1])
     stop(format_message(msg), call. = FALSE)
   }
 

--- a/R/get_varcov_sandwich.R
+++ b/R/get_varcov_sandwich.R
@@ -123,7 +123,7 @@
   # extract variance-covariance matrix
   if (!inherits(.vcov, "matrix")) {
     msg <- sprintf("Unable to extract a variance-covariance matrix for model object of class `%s`. Different values of the `vcov` argument trigger calls to the `sandwich` or `clubSandwich` packages in order to extract the matrix (see `?insight::get_varcov`). Your model may not be supported by one or both of those packages.", class(x)[1])
-    stop(format_message(msg))
+    stop(format_message(msg), call. = FALSE)
   }
 
   .vcov

--- a/R/get_varcov_sandwich.R
+++ b/R/get_varcov_sandwich.R
@@ -1,0 +1,127 @@
+# Get Variance-covariance Matrix ---------------------------------------------------
+
+.get_varcov_sandwich <- function(x,
+                                 vcov_fun = NULL,
+                                 vcov_args = NULL,
+                                 verbose = TRUE,
+                                 ...) {
+  dots <- list(...)
+
+  # deprecated
+  if (isTRUE(verbose) && "vcov_type" %in% names(dots)) {
+    warning(format_message("The `vcov_type` argument is superseded by the `vcov_args` argument."), call. = FALSE)
+  }
+  if (isTRUE(verbose) && "robust" %in% names(dots)) {
+    warning(format_message("The `robust` argument is superseded by the `vcov` argument."), call. = FALSE)
+  }
+
+  if (is.null(vcov_args)) {
+    vcov_args <- list()
+  }
+
+  # deprecated: `vcov_estimation`
+  if (is.null(vcov_fun) && "vcov_estimation" %in% names(dots)) {
+    vcov_fun <- dots[["vcov_estimation"]]
+  }
+
+  # deprecated: `robust`
+  if (isTRUE(dots[["robust"]]) && is.null(vcov_fun)) {
+    dots[["robust"]] <- NULL
+    vcov_fun <- "HC3"
+  }
+
+  # deprecated: `vcov_type`
+  if ("vcov_type" %in% names(dots)) {
+    if (!"type" %in% names(vcov_args)) {
+      vcov_args[["type"]] <- dots[["vcov_type"]]
+    }
+  }
+
+  # vcov_fun is a matrix
+  if (is.matrix(vcov_fun)) {
+    return(vcov_fun)
+  }
+
+  # vcov_fun is a function
+  if (is.function(vcov_fun)) {
+    if (is.null(vcov_args) || !is.list(vcov_args)) {
+      args <- list(x)
+    } else {
+      args <- c(list(x), vcov_args)
+    }
+    .vcov <- do.call("vcov_fun", args)
+    return(.vcov)
+  }
+
+  # type shortcuts: overwrite only if not supplied explicitly by the user
+  if (!"type" %in% names(vcov_args)) {
+    if (isTRUE(vcov_fun %in% c(
+      "HC0", "HC1", "HC2", "HC3", "HC4", "HC4m", "HC5",
+      "CR0", "CR1", "CR1p", "CR1S", "CR2", "CR3", "xy",
+      "residual", "wild", "mammen", "webb"
+    ))) {
+      vcov_args[["type"]] <- vcov_fun
+    }
+  }
+
+  # default vcov matrix
+  if (is.null(vcov_fun)) {
+    .vcov <- get_varcov(x, ...)
+    return(.vcov)
+  }
+
+  if (!grepl("^(vcov|kernHAC|NeweyWest)", vcov_fun)) {
+    vcov_fun <- switch(vcov_fun,
+      "HC0" = ,
+      "HC1" = ,
+      "HC2" = ,
+      "HC3" = ,
+      "HC4" = ,
+      "HC4m" = ,
+      "HC5" = ,
+      "HC" = "vcovHC",
+      "CR0" = ,
+      "CR1" = ,
+      "CR1p" = ,
+      "CR1S" = ,
+      "CR2" = ,
+      "CR3" = ,
+      "CR" = "vcovCR",
+      "xy" = ,
+      "residual" = ,
+      "wild" = ,
+      "mammen" = ,
+      "webb" = ,
+      "BS" = "vcovBS",
+      "OPG" = "vcovOPG",
+      "HAC" = "vcovHAC",
+      "PC" = "vcovPC",
+      "CL" = "vcovCL",
+      "PL" = "vcovPL"
+    )
+  }
+
+  # check if required package is available
+  if (vcov_fun == "vcovCR") {
+    check_if_installed("clubSandwich", reason = "to get cluster-robust standard errors")
+    fun <- get(vcov_fun, asNamespace("clubSandwich"))
+  } else {
+    check_if_installed("sandwich", reason = "to get robust standard errors")
+    fun <- try(get(vcov_fun, asNamespace("sandwich")), silent = TRUE)
+    if (!is.function(fun)) {
+      stop(sprintf("`%s` is not a function exported by the `sandwich` package.", vcov_fun))
+    }
+  }
+
+  # extract variance-covariance matrix
+  .vcov <- do.call(fun, c(list(x), vcov_args))
+
+  # clubSandwich output has a weird class
+  if (inherits(.vcov, c("vcovCR", "clubSandwich"))) {
+    .vcov <- as.matrix(.vcov)
+  }
+
+  .vcov
+}
+
+

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -4,12 +4,9 @@
 \alias{get_varcov}
 \alias{get_varcov.default}
 \alias{get_varcov.betareg}
-\alias{get_varcov.DirichletRegModel}
 \alias{get_varcov.clm2}
 \alias{get_varcov.truncreg}
-\alias{get_varcov.gamlss}
 \alias{get_varcov.hurdle}
-\alias{get_varcov.zcpglm}
 \alias{get_varcov.glmmTMB}
 \alias{get_varcov.MixMod}
 \alias{get_varcov.brmsfit}
@@ -29,18 +26,9 @@ get_varcov(x, ...)
   ...
 )
 
-\method{get_varcov}{DirichletRegModel}(
-  x,
-  component = c("conditional", "precision", "all"),
-  verbose = TRUE,
-  ...
-)
-
 \method{get_varcov}{clm2}(x, component = c("all", "conditional", "scale"), ...)
 
 \method{get_varcov}{truncreg}(x, component = c("conditional", "all"), ...)
-
-\method{get_varcov}{gamlss}(x, component = c("conditional", "all"), ...)
 
 \method{get_varcov}{hurdle}(
   x,
@@ -49,8 +37,6 @@ get_varcov(x, ...)
   vcov_args = NULL,
   ...
 )
-
-\method{get_varcov}{zcpglm}(x, component = c("conditional", "zero_inflated", "zi", "all"), ...)
 
 \method{get_varcov}{glmmTMB}(
   x,

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -144,7 +144,7 @@ if (require("pscl") && require("sandwich")) {
   mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
   get_varcov(
     mod,
-    component = "zero_inflated",
+    component = "conditional",
     vcov = "BS",
     vcov_args = list(R = 50)
   )

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -130,4 +130,23 @@ in case of a negative variance-covariance matrix.
 data(mtcars)
 m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 get_varcov(m)
+
+# vcov of zero-inflation component from hurdle-model
+if (require("pscl")) {
+  data("bioChemists", package = "pscl")
+  mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+  get_varcov(mod, component = "zero_inflated")
+}
+
+# robust vcov of, count component from hurdle-model
+if (require("pscl") && require("sandwich")) {
+  data("bioChemists", package = "pscl")
+  mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+  get_varcov(
+    mod,
+    component = "zero_inflated",
+    vcov = "BS",
+    vcov_args = list(R = 50)
+  )
+}
 }

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -56,7 +56,6 @@ get_varcov(x, ...)
   x,
   effects = c("fixed", "random"),
   component = c("conditional", "zero_inflated", "zi", "dispersion", "auxiliary", "all"),
-  robust = FALSE,
   verbose = TRUE,
   ...
 )

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -20,7 +20,7 @@
 \usage{
 get_varcov(x, ...)
 
-\method{get_varcov}{default}(x, verbose = TRUE, ...)
+\method{get_varcov}{default}(x, verbose = TRUE, vcov = NULL, vcov_args = NULL, ...)
 
 \method{get_varcov}{betareg}(
   x,
@@ -76,6 +76,24 @@ get_varcov(x, ...)
 
 \item{verbose}{Toggle warnings.}
 
+\item{vcov}{Variance-covariance matrix used to compute uncertainty estimates (e.g., for robust standard errors). This argument accepts a covariance matrix, a function which returns a covariance matrix, or a string which identifies the function to be used to compute the covariance matrix.
+\itemize{
+\item A covariance matrix
+\item A function which returns a covariance matrix (e.g., \code{stats::vcov()})
+\item A string which indicates the kind of uncertainty estimates to return.
+\itemize{
+\item Heteroskedasticity-consistent: \code{"vcovHC"}, \code{"HC"}, \code{"HC0"}, \code{"HC1"}, \code{"HC2"}, \code{"HC3"}, \code{"HC4"}, \code{"HC4m"}, \code{"HC5"}. See \code{?sandwich::vcovHC}
+\item Cluster-robust: \code{"vcovCR"}, \code{"CR0"}, \code{"CR1"}, \code{"CR1p"}, \code{"CR1S"}, \code{"CR2"}, \code{"CR3"}. See \code{?clubSandwich::vcovCR()}
+\item Bootstrap: \code{"vcovBS"}, \code{"xy"}, \code{"residual"}, \code{"wild"}, \code{"mammen"}, \code{"webb"}. See \code{?sandwich::vcovBS}
+\item Other \code{sandwich} package functions: \code{"vcovHAC"}, \code{"vcovPC"}, \code{"vcovCL"}, \code{"vcovPL"}.
+}
+}}
+
+\item{vcov_args}{List of arguments to be passed to the function identified by
+the \code{vcov} argument. This function is typically supplied by the \strong{sandwich}
+or \strong{clubSandwich} packages. Please refer to their documentation (e.g.,
+\code{?sandwich::vcovHAC}) to see the list of available arguments.}
+
 \item{component}{Should the complete variance-covariance matrix of the model
 be returned, or only for specific model components only (like count or
 zero-inflated model parts)? Applies to models with zero-inflated component,
@@ -88,9 +106,6 @@ model.}
 \item{effects}{Should the complete variance-covariance matrix of the model
 be returned, or only for specific model parameters only? Currently only
 applies to models of class \code{mixor}.}
-
-\item{robust}{Logical, if \code{TRUE}, returns a robust variance-covariance matrix
-using sandwich estimation.}
 
 \item{complete}{Logical, if \code{TRUE}, for \code{aov}, returns the full
 variance-covariance matrix.}

--- a/man/get_varcov.Rd
+++ b/man/get_varcov.Rd
@@ -42,7 +42,13 @@ get_varcov(x, ...)
 
 \method{get_varcov}{gamlss}(x, component = c("conditional", "all"), ...)
 
-\method{get_varcov}{hurdle}(x, component = c("conditional", "zero_inflated", "zi", "all"), ...)
+\method{get_varcov}{hurdle}(
+  x,
+  component = c("conditional", "zero_inflated", "zi", "all"),
+  vcov = NULL,
+  vcov_args = NULL,
+  ...
+)
 
 \method{get_varcov}{zcpglm}(x, component = c("conditional", "zero_inflated", "zi", "all"), ...)
 

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -48,6 +48,7 @@ test_that("mgcv", {
 
 
 .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
+.runStanTest <- Sys.getenv("RunAllinsightStanTests") == "yes"
 
 if (.runThisTest) {
   data(iris)
@@ -78,14 +79,16 @@ if (.runThisTest) {
   out <- get_data(m)
   expect_equal(out, iris[c("Sepal.Length", "Sepal.Width")], ignore_attr = TRUE)
 
-  requiet("brms")
-  m <- suppressWarnings(brms::brm(mpg ~ hp + mo(cyl), data = mtcars, refresh = 0, iter = 200, chains = 1))
-  out <- get_data(m)
-  expect_equal(attributes(out)$factors, "cyl")
-  expect_type(out$cyl, "double")
-  expect_equal(colnames(out), c("mpg", "hp", "cyl"))
+  if (.runStanTest) {
+    requiet("brms")
+    m <- suppressWarnings(brms::brm(mpg ~ hp + mo(cyl), data = mtcars, refresh = 0, iter = 200, chains = 1))
+    out <- get_data(m)
+    expect_equal(attributes(out)$factors, "cyl")
+    expect_type(out$cyl, "double")
+    expect_equal(colnames(out), c("mpg", "hp", "cyl"))
 
-  out <- get_datagrid(m)
-  expect_equal(dim(out), c(10, 2))
-  expect_equal(out$cyl, c(4, 4, 6, 6, 8, 8, 8, 8, 8, 8))
+    out <- get_datagrid(m)
+    expect_equal(dim(out), c(10, 2))
+    expect_equal(out$cyl, c(4, 4, 6, 6, 8, 8, 8, 8, 8, 8))
+  }
 }

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -5,9 +5,12 @@ test_that("informative error in get_varcov.default", {
     requiet("lme4")
     mod <- lmer(mpg ~ hp + (1 | cyl), data = mtcars)
     # sandwich: not supported
-    expect_error(get_varcov(mod, vcov = "HC2"), regexp = "not be supported")
+    expect_error(get_varcov(mod, vcov = "HC2"))
     # clubSandwich: supported
-    expect_error(get_varcov(mod, vcov = "CR0"), NA)
+    expect_equal(get_varcov(mod, vcov = "CR0"),
+                 clubSandwich::vcovCR(mod, type = "CR0"),
+                 tolerance = 1e-4,
+                 ignore_attr = TRUE)
 })
 
 test_that("lm: sandwich", {

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -38,6 +38,6 @@ test_that("warning: not yet supported", {
   requiet("pscl")
   data("bioChemists", package = "pscl")
   mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
-  expect_warning(get_varcov(mod, vcov = "HC3"), regexp = "not yet supported")
+  expect_error(get_varcov(mod, vcov = "HC3"), regexp = "supported by one or")
 })
 

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -33,3 +33,11 @@ test_that("lm: clubSandwich", {
                  ignore_attr = TRUE)
 })
 
+
+test_that("warning: not yet supported", {
+  requiet("pscl")
+  data("bioChemists", package = "pscl")
+  mod <- hurdle(art ~ phd + fem | ment, data = bioChemists, dist = "negbin")
+  expect_warning(get_varcov(mod, vcov = "HC3"), regexp = "not yet supported")
+})
+

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -1,10 +1,13 @@
 requiet("sandwich")
 requiet("clubSandwich")
 
-test_that("warning in generic get_varcov: unsupported by sandwich", {
+test_that("informative error in get_varcov.default", {
     requiet("lme4")
     mod <- lmer(mpg ~ hp + (1 | cyl), data = mtcars)
-    expect_error(expect_warning(get_varcov(mod, vcov = "HC2"), regexp = "not be supported"))
+    # sandwich: not supported
+    expect_error(get_varcov(mod, vcov = "HC2"), regexp = "not be supported")
+    # clubSandwich: supported
+    expect_error(get_varcov(mod, vcov = "CR0"), NA)
 })
 
 test_that("lm: sandwich", {
@@ -22,7 +25,9 @@ test_that("lm: sandwich", {
 
 test_that("lm: clubSandwich", {
     mod <- lm(mpg ~ hp * wt, data = mtcars)
-    expect_equal(get_varcov(mod, vcov = "CR", vcov_args = list(cluster = mtcars$cyl, type = "CR0")),
+    expect_equal(get_varcov(mod,
+                            vcov = "CR",
+                            vcov_args = list(cluster = mtcars$cyl, type = "CR0")),
                  clubSandwich::vcovCR(mod, cluster = mtcars$cyl, type = "CR0"),
                  tolerance = 1e-5,
                  ignore_attr = TRUE)

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -1,0 +1,25 @@
+requiet("sandwich")
+requiet("clubSandwich")
+
+test_that("lm: sandwich", {
+    mod <- lm(mpg ~ hp * wt, data = mtcars)
+    expect_equal(get_varcov(mod, vcov = "HC1"),
+                 vcovHC(mod, type = "HC1"))
+    expect_equal(get_varcov(mod, vcov = "HC4"),
+                 vcovHC(mod, type = "HC4"))
+    expect_equal(get_varcov(mod, vcov = "HC", vcov_args = list(type = "HC4")),
+                 vcovHC(mod, type = "HC4"))
+    expect_equal(get_varcov(mod, vcov = vcovOPG),
+                 vcovOPG(mod),
+                 tolerance = 1e-5)
+})
+
+
+test_that("lm: clubSandwich", {
+    mod <- lm(mpg ~ hp * wt, data = mtcars)
+    expect_equal(get_varcov(mod, vcov = "CR", vcov_args = list(cluster = mtcars$cyl, type = "CR0")),
+                 clubSandwich::vcovCR(mod, cluster = mtcars$cyl, type = "CR0"),
+                 tolerance = 1e-5,
+                 ignore_attr = TRUE)
+})
+

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -1,6 +1,12 @@
 requiet("sandwich")
 requiet("clubSandwich")
 
+test_that("warning in generic get_varcov: unsupported by sandwich", {
+    requiet("lme4")
+    mod <- lmer(mpg ~ hp + (1 | cyl), data = mtcars)
+    expect_error(expect_warning(get_varcov(mod, vcov = "HC2"), regexp = "not be supported"))
+})
+
 test_that("lm: sandwich", {
     mod <- lm(mpg ~ hp * wt, data = mtcars)
     expect_equal(get_varcov(mod, vcov = "HC1"),
@@ -13,7 +19,6 @@ test_that("lm: sandwich", {
                  vcovOPG(mod),
                  tolerance = 1e-5)
 })
-
 
 test_that("lm: clubSandwich", {
     mod <- lm(mpg ~ hp * wt, data = mtcars)

--- a/tests/testthat/test-zeroinfl.R
+++ b/tests/testthat/test-zeroinfl.R
@@ -1,3 +1,5 @@
+.runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
+
 if (requiet("testthat") &&
   requiet("insight") &&
   requiet("pscl")) {
@@ -133,6 +135,24 @@ if (requiet("testthat") &&
     )
   })
 
+
+  if (.runThisTest && requiet("sandwich")) {
+    set.seed(123)
+    vc1 <- get_varcov(m1, component = "all", vcov = "BS", vcov_args = list(R = 50))
+    set.seed(123)
+    vc2 <- sandwich::vcovBS(m1, R = 50)
+    expect_equal(vc1, vc2, ignore_attr = TRUE)
+
+    set.seed(123)
+    vc1 <- get_varcov(m1, component = "conditional", vcov = "BS", vcov_args = list(R = 50))
+    count_col <- grepl("^count_", colnames(vc2))
+    expect_equal(vc1, vc2[count_col, count_col], ignore_attr = TRUE)
+
+    set.seed(123)
+    vc1 <- get_varcov(m1, component = "zero_inflated", vcov = "BS", vcov_args = list(R = 50))
+    zero_col <- grepl("^zero_", colnames(vc2))
+    expect_equal(vc1, vc2[zero_col, zero_col], ignore_attr = TRUE)
+  }
 
   m2 <- zeroinfl(formula = art ~ . | 1, data = bioChemists, dist = "negbin")
   .runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"


### PR DESCRIPTION
Currently only works for `get_varcov.default()`

Question/Problem: All `get_varcov.CLASS()` methods accept `...`. This means that when `sandwich` does not support a model, the `vcov` argument will be absorbed silently and return an IID var-cov without any warning.

Do we have to introduce explicit warnings in every single method where `sandwich` doesn't work? What is the most elegant way to do that?