### PR TITLE
CIs are not needed

### DIFF
--- a/R/get_loglikelihood.R
+++ b/R/get_loglikelihood.R
@@ -179,7 +179,7 @@ get_loglikelihood.afex_aov <- function(x, ...) {
   w <- get_weights(x, null_as_ones = TRUE)
   dev <- stats::deviance(x)
   disp <- dev / sum(w)
-  predicted <- get_predicted(x, verbose = verbose)
+  predicted <- get_predicted(x, ci = NULL, verbose = verbose)
 
   # Make adjustment for binomial models with matrix as input
   if (info$is_binomial) {


### PR DESCRIPTION
Since `modelsummary` switched to easystats, I've had several reports of GLM models be extremely slow (borderline unusable) when N>10K. I think part of the problem is the *IC statistics, which rely on this function, which calls the slow CI predictions.

This is a critical issue for me.

https://github.com/easystats/insight/issues/585