### PR TITLE
Format bf exact

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# insight 0.18.0.9990
+
+## Breaking changes
+
+* `format_bf()`'s `exact` argument now defaults to `exact = TRUE`. To preserve previous behavior, set `format_bf(..., exact = FALSE)`
+
 # insight 0.18.0
 
 ## Breaking changes

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -12,7 +12,7 @@
 #'
 #' @examples
 #' format_bf(bfs <- c(0.000045, 0.033, NA, 1557, 3.54))
-#' format_bf(bfs, exact = TRUE, name = NULL)
+#' format_bf(bfs, exact = FALSE, name = NULL)
 #' format_bf(bfs, stars = TRUE)
 #' format_bf(bfs, protect_ratio = TRUE)
 #' format_bf(bfs, protect_ratio = TRUE, exact = TRUE)
@@ -24,7 +24,7 @@ format_bf <- function(bf,
                       name = "BF",
                       protect_ratio = FALSE,
                       na_reference = NA,
-                      exact = FALSE) {
+                      exact = TRUE) {
   if (!is.na(na_reference)) {
     bf[is.na(bf)] <- na_reference
   } else {

--- a/R/format_table.R
+++ b/R/format_table.R
@@ -492,11 +492,11 @@ format_table <- function(x,
 
 .format_bayes_columns <- function(x, stars, rope_digits = 2, zap_small, ci_width = "auto", ci_brackets = TRUE) {
   # Indices
-  if ("BF" %in% names(x)) x$BF <- format_bf(x$BF, name = NULL, stars = stars)
   if ("log_BF" %in% names(x)) {
-    x$BF <- format_bf(exp(x$log_BF), name = NULL, stars = stars)
+    x$BF <- exp(x$log_BF)
     x$log_BF <- NULL
   }
+  if ("BF" %in% names(x)) x$BF <- format_bf(x$BF, name = NULL, stars = stars)
   if ("pd" %in% names(x)) x$pd <- format_pd(x$pd, name = NULL, stars = stars)
   if ("Rhat" %in% names(x)) x$Rhat <- format_value(x$Rhat, digits = 3)
   if ("ESS" %in% names(x)) x$ESS <- round(x$ESS)

--- a/man/format_bf.Rd
+++ b/man/format_bf.Rd
@@ -11,7 +11,7 @@ format_bf(
   name = "BF",
   protect_ratio = FALSE,
   na_reference = NA,
-  exact = FALSE
+  exact = TRUE
 )
 }
 \arguments{
@@ -39,7 +39,7 @@ Bayes Factor formatting
 }
 \examples{
 format_bf(bfs <- c(0.000045, 0.033, NA, 1557, 3.54))
-format_bf(bfs, exact = TRUE, name = NULL)
+format_bf(bfs, exact = FALSE, name = NULL)
 format_bf(bfs, stars = TRUE)
 format_bf(bfs, protect_ratio = TRUE)
 format_bf(bfs, protect_ratio = TRUE, exact = TRUE)

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -47,8 +47,18 @@ if (requiet("testthat") && requiet("insight")) {
 
   test_that("format others", {
     expect_true(is.character(insight::format_pd(0.02)))
-    expect_equal(nchar(format_bf(4)), 9)
     expect_true(is.character(format_rope(0.02)))
+
+    Bf <- c(3, 100, 1001)
+    Bf <- c(rev(1/Bf), 1, Bf)
+    expect_equal(format_bf(Bf, name = NULL),
+                 c("9.99e-04", "0.010", "0.333", "1.00", "3.00", "100.00", "1.00e+03"))
+    expect_equal(format_bf(Bf, name = NULL, exact = FALSE),
+                 c("< 0.001", "0.010", "0.333", "1.00", "3.00", "100.00", "> 1000"))
+    expect_equal(format_bf(Bf, name = NULL, protect_ratio = TRUE),
+                 c("1/1.00e+03", "1/100.00", "1/3.00", "1.00", "3.00", "100.00", "1.00e+03"))
+    expect_equal(format_bf(Bf, name = NULL, exact = FALSE, protect_ratio = TRUE),
+                 c("< 1/1000", "1/100.00", "1/3.00", "1.00", "3.00", "100.00", "> 1000"))
   })
 
   test_that("format_number", {


### PR DESCRIPTION
_Originally posted #589_

Since BFs are translational, BF<sub>A vs B</sub> / BF<sub>C vs B</sub> = BF<sub>A vs C</sub>

However, with the current default behavior of `format_bf(..., exact = FALSE)` information is lost and this property of BFs cannot be used.
(I just saw “BF \> 1000” in a paper along with other `{report}` text, so I’m tracing this back to here.)

``` r
library(insight)
library(bayestestR)

m1 <- lm(mpg ~ 1, mtcars)
m2 <- lm(mpg ~ hp, mtcars)
m3 <- lm(mpg ~ cyl, mtcars)

Bfs <- bayesfactor_models(m2, m3, denominator = m1)
```

**Old behavior**: Can’t infer that `m3` is supported over `m2` - 

``` r
format_bf(exp(Bfs$log_BF))
#> [1] "BF > 1000" "BF > 1000" "BF = 1.00"
```

**New behavior**: Can infer that `m3` is supported over `m2` - 

``` r
format_bf(exp(Bfs$log_BF))
#> [1] "BF = 4.54e+05" "BF = 1.77e+08" "BF = 1.00"
```


