### PR TITLE
Faster `is_empty_object`

### DIFF
--- a/R/utils_object.R
+++ b/R/utils_object.R
@@ -17,14 +17,15 @@ is_empty_object <- function(x) {
 
   if (inherits(x, "data.frame")) {
     x <- as.data.frame(x)
+    flag_empty <- TRUE
     if (nrow(x) > 0 && ncol(x) > 0) {
-      x <- x[, !sapply(x, function(i) all(is.na(i))), drop = FALSE]
-      # this is much faster than apply(x, 1, FUN)
-      flag_empty <- all(rowSums(is.na(x)) == ncol(x))
-    } else {
-      flag_empty <- TRUE
+      i <- 0
+      while (flag_empty == TRUE && i <= ncol(x)) {
+        i <- i + 1
+        flag_empty <- all(is.na(x[[i]]))
+      }
     }
-    # a list but not a data.frame
+  # a list but not a data.frame
   } else if (is.list(x) && length(x) > 0) {
     x <- tryCatch(
       {


### PR DESCRIPTION
`is_empty_object()` is extremely slow when applied to data frames, and this in turn slows down a bunch of other functions like `get_data()`. (Also see: https://github.com/vincentarelbundock/modelsummary/issues/479)

Currently, the function does this:

```r
x <- x[, !sapply(x, function(i) all(is.na(i))), drop = FALSE]
flag_empty <- all(rowSums(is.na(x)) == ncol(x))
```

The first line assigns `x` to the subset of columns with at least one non-`NA` value. The second line checks if all rows of that subset are completely `NA`. But by construction, the second check should always pass if we have at least one column with at least one non-`NA` value. So it's redundant and wasteful.

Am I misunderstanding the logic?

If this is right, then this PR improves the situation by looping over columns and returning `flag_empty==FALSE` immediately when it finds one column which includes one non-`NA` value. In large datasets, this can be much faster than checking all columns. 