### PR TITLE
`find_formula` evaluates symbol in call

### DIFF
--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -316,9 +316,19 @@ find_formula.marginaleffects <- function(x, verbose = TRUE, ...) {
 #' @export
 find_formula.selection <- function(x, verbose = TRUE, ...) {
   model_call <- parse(text = deparse(get_call(x)))[[1]]
+  # formulas directly in the call
+  f_selection <- tryCatch(stats::as.formula(model_call$selection), error = function(e) NULL)
+  f_outcome <- tryCatch(stats::as.formula(model_call$outcome), error = function(e) NULL)
+  # formulas as symbols (assigned to an object, which is then used in the call)
+  if (is.null(f_selection)) {
+    f_selection <- stats::as.formula(eval(model_call$selection))
+  }
+  if (is.null(f_outcome)) {
+    f_outcome <- stats::as.formula(eval(model_call$outcome))
+  }
   f <- list(conditional = list(
-    selection = stats::as.formula(model_call$selection),
-    outcome = stats::as.formula(model_call$outcome)
+    selection = f_selection,
+    outcome = f_outcome
   ))
   attr(f, "two_stage") <- TRUE
   .find_formula_return(f, verbose = verbose)


### PR DESCRIPTION
Problem: sometimes users assign a formula to an object, and then feeds that object to the formula parameter of a fitting function. In the `selection` model type, this poses problems because we extract the formula from the model call, and the apply `stats::as.formula` directly to that. But if the call includes a symbol rather than the formula itself, this breaks. We need to evaluate the symbol before calling `as.formula`.

This is a simple PR with a `tryCatch` and a 2nd attempt with `eval()`