### PR TITLE
format_message accepts tokens

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.18.2
+Version: 0.18.2.1
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# insight 0.18.1
+# insight 0.18.3
+
+## Changes to functions
+
+* `format_message()` gets some additional formatting features. See 'Details'
+  in `?format_message` for more information and some current limitations.
+
+# insight 0.18.2
 
 ## New functions
 

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -92,11 +92,9 @@ format_message <- function(string, ..., line_length = 0.9 * options()$width) {
 
   # remove tokens from temporary string, so we can detect the "real" line length
   if (!is.null(which_tokens)) {
-    for (i in token_pattern[which_tokens]) {
-      tmp_string <- gsub(i, "\\1", tmp_string)
-    }
-    # protect tokens from line break
     for (i in which(which_tokens)) {
+      tmp_string <- gsub(token_pattern[i], "\\1", tmp_string)
+      # protect tokens from line break
       string <- gsub(token_pattern[i], token_protected[i], string)
     }
   } else {

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -14,7 +14,12 @@
 #' You can use `{.b text}` for bold and `{.i text}` formatting. Furthermore,
 #' `{.url www.url.com}` formats the string as URL (i.e., enclosing URL in
 #' `<` and `>`, blue color and italic font style), while `{.pkg packagename}`
-#' formats the text in blue color.
+#' formats the text in blue color. This features has some limitations:
+#' it's hard to detect the each line length for multiple lines when the string
+#' contains formatting tags. Thus, it can happen that lines are wrapped at an
+#' earlier length than expected. Furthermore, if you have multiple words in a
+#' format tag (`{.b one two three}``), a line break might occur inside this tag,
+#' and the formatting no longer works (messing up the message-string).
 #'
 #' @return A formatted string.
 #' @examples
@@ -31,7 +36,7 @@
 #' )
 #' message(msg)
 #'
-#' # Caution, experimental!
+#' # Caution, experimental! See 'Details'
 #' msg <- format_message(
 #'   "This is {.i italic}, visit {.url easystats.github.io/easystats}",
 #'   line_length = 30

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -52,8 +52,10 @@ format_message <- function(string, ..., line_length = 0.9 * options()$width) {
   lsub <- 0
   tmp_string <- string
 
+  # these chars are allowed inside a token, e.g. "{.i allowedchars}"
+  allowed_chars <- "([a-zA-Z:\\./\\+-]*)"
   # supported tokens, create regex pattern
-  token_pattern <- sprintf("\\{\\.%s (.*)\\}", c("b", "i", "url", "pkg"))
+  token_pattern <- sprintf("\\{\\.%s %s\\}", c("b", "i", "url", "pkg"), allowed_chars)
   # for line breaks, we "protect" these patterns
   token_protected <- sprintf("\\{\\.%s_\\1\\}", c("b", "i", "url", "pkg"))
 
@@ -100,27 +102,31 @@ format_message <- function(string, ..., line_length = 0.9 * options()$width) {
     for (i in which(which_tokens)) {
       if (token_pattern[i] == "\\{\\.b (.*)\\}") {
         # bold formatting
-        s1 <- gsub("(.*)\\{\\.b_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\1", string)
-        s2 <- gsub("(.*)\\{\\.b_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\2", string)
-        s3 <- gsub("(.*)\\{\\.b_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\3", string)
+        pattern <- paste0("(.*)\\{\\.b_", allowed_chars, "\\}(.*)")
+        s1 <- gsub(pattern, "\\1", string)
+        s2 <- gsub(pattern, "\\2", string)
+        s3 <- gsub(pattern, "\\3", string)
         s2 <- .bold(s2)
       } else if (token_pattern[i] == "\\{\\.i (.*)\\}") {
         # italic formatting
-        s1 <- gsub("(.*)\\{\\.i_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\1", string)
-        s2 <- gsub("(.*)\\{\\.i_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\2", string)
-        s3 <- gsub("(.*)\\{\\.i_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\3", string)
+        pattern <- paste0("(.*)\\{\\.i_", allowed_chars, "\\}(.*)")
+        s1 <- gsub(pattern, "\\1", string)
+        s2 <- gsub(pattern, "\\2", string)
+        s3 <- gsub(pattern, "\\3", string)
         s2 <- .italic(s2)
       } else if (token_pattern[i] == "\\{\\.url (.*)\\}") {
         # url formatting
-        s1 <- gsub("(.*)\\{\\.url_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\1", string)
-        s2 <- gsub("(.*)\\{\\.url_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\2", string)
-        s3 <- gsub("(.*)\\{\\.url_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\3", string)
+        pattern <- paste0("(.*)\\{\\.url_", allowed_chars, "\\}(.*)")
+        s1 <- gsub(pattern, "\\1", string)
+        s2 <- gsub(pattern, "\\2", string)
+        s3 <- gsub(pattern, "\\3", string)
         s2 <- .italic(.blue(paste0("<", s2, ">")))
       } else if (token_pattern[i] == "\\{\\.pkg (.*)\\}") {
-        # url formatting
-        s1 <- gsub("(.*)\\{\\.pkg_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\1", string)
-        s2 <- gsub("(.*)\\{\\.pkg_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\2", string)
-        s3 <- gsub("(.*)\\{\\.pkg_([a-zA-Z:\\./\\+-]*)\\}(.*)", "\\3", string)
+        # package formatting
+        pattern <- paste0("(.*)\\{\\.pkg_", allowed_chars, "\\}(.*)")
+        s1 <- gsub(pattern, "\\1", string)
+        s2 <- gsub(pattern, "\\2", string)
+        s3 <- gsub(pattern, "\\3", string)
         s2 <- .blue(s2)
       }
       string <- paste0(s1, s2, s3)

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -100,28 +100,28 @@ format_message <- function(string, ..., line_length = 0.9 * options()$width) {
   # convert tokens into formatting
   if (!is.null(which_tokens)) {
     for (i in which(which_tokens)) {
-      if (token_pattern[i] == "\\{\\.b (.*)\\}") {
+      if (token_pattern[i] == token_pattern[1]) {
         # bold formatting
         pattern <- paste0("(.*)\\{\\.b_", allowed_chars, "\\}(.*)")
         s1 <- gsub(pattern, "\\1", string)
         s2 <- gsub(pattern, "\\2", string)
         s3 <- gsub(pattern, "\\3", string)
         s2 <- .bold(s2)
-      } else if (token_pattern[i] == "\\{\\.i (.*)\\}") {
+      } else if (token_pattern[i] == token_pattern[2]) {
         # italic formatting
         pattern <- paste0("(.*)\\{\\.i_", allowed_chars, "\\}(.*)")
         s1 <- gsub(pattern, "\\1", string)
         s2 <- gsub(pattern, "\\2", string)
         s3 <- gsub(pattern, "\\3", string)
         s2 <- .italic(s2)
-      } else if (token_pattern[i] == "\\{\\.url (.*)\\}") {
+      } else if (token_pattern[i] == token_pattern[3]) {
         # url formatting
         pattern <- paste0("(.*)\\{\\.url_", allowed_chars, "\\}(.*)")
         s1 <- gsub(pattern, "\\1", string)
         s2 <- gsub(pattern, "\\2", string)
         s3 <- gsub(pattern, "\\3", string)
         s2 <- .italic(.blue(paste0("<", s2, ">")))
-      } else if (token_pattern[i] == "\\{\\.pkg (.*)\\}") {
+      } else if (token_pattern[i] == token_pattern[4]) {
         # package formatting
         pattern <- paste0("(.*)\\{\\.pkg_", allowed_chars, "\\}(.*)")
         s1 <- gsub(pattern, "\\1", string)

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -11,15 +11,19 @@
 #'
 #' @details
 #' There is an experimental formatting feature implemented in this function.
-#' You can use `{.b text}` for bold and `{.i text}` formatting. Furthermore,
-#' `{.url www.url.com}` formats the string as URL (i.e., enclosing URL in
-#' `<` and `>`, blue color and italic font style), while `{.pkg packagename}`
-#' formats the text in blue color. This features has some limitations:
-#' it's hard to detect the each line length for multiple lines when the string
-#' contains formatting tags. Thus, it can happen that lines are wrapped at an
-#' earlier length than expected. Furthermore, if you have multiple words in a
-#' format tag (`{.b one two three}`), a line break might occur inside this tag,
-#' and the formatting no longer works (messing up the message-string).
+#' You can use following tags:
+#' * `{.b text}` for bold formatting
+#' * `{.i text}` to use italic font style
+#' * `{.url www.url.com}` formats the string as URL (i.e., enclosing URL in
+#' `<` and `>`, blue color and italic font style)
+#' * `{.pkg packagename}` formats the text in blue color.
+#'
+#' This features has some limitations: it's hard to detect the each line length
+#' for multiple lines when the string contains formatting tags. Thus, it can
+#' happen that lines are wrapped at an earlier length than expected. Furthermore,
+#' if you have multiple words in a format tag (`{.b one two three}`), a line
+#' break might occur inside this tag, and the formatting no longer works
+#' (messing up the message-string).
 #'
 #' @return A formatted string.
 #' @examples

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -9,6 +9,13 @@
 #' @param ... Further strings that will be concatenated as indented new lines.
 #' @param line_length Numeric, the maximum length of a line.
 #'
+#' @details
+#' There is an experimental formatting feature implemented in this function.
+#' You can use `{.b text}` for bold and `{.i text}` formatting. Furthermore,
+#' `{.url www.url.com}` formats the string as URL (i.e., enclosing URL in
+#' `<` and `>`, blue color and italic font style), while `{.pkg packagename}`
+#' formats the text in blue color.
+#'
 #' @return A formatted string.
 #' @examples
 #' msg <- format_message("Much too long string for just one line, I guess!",
@@ -23,6 +30,14 @@
 #'   line_length = 30
 #' )
 #' message(msg)
+#'
+#' # Caution, experimental!
+#' msg <- format_message(
+#'   "This is {.i italic}, visit {.url easystats.github.io/easystats}",
+#'   line_length = 30
+#' )
+#' message(msg)
+#'
 #' @export
 format_message <- function(string, ..., line_length = 0.9 * options()$width) {
   if (is.null(line_length) || is.infinite(line_length) || line_length < 1) {

--- a/R/format_message.R
+++ b/R/format_message.R
@@ -18,7 +18,7 @@
 #' it's hard to detect the each line length for multiple lines when the string
 #' contains formatting tags. Thus, it can happen that lines are wrapped at an
 #' earlier length than expected. Furthermore, if you have multiple words in a
-#' format tag (`{.b one two three}``), a line break might occur inside this tag,
+#' format tag (`{.b one two three}`), a line break might occur inside this tag,
 #' and the formatting no longer works (messing up the message-string).
 #'
 #' @return A formatted string.

--- a/man/format_message.Rd
+++ b/man/format_message.Rd
@@ -21,6 +21,13 @@ Inserts line breaks into a longer message or warning string.
 Line length is adjusted to maximum length of the console, if the width
 can be accessed. By default, new lines are indented by two whitespace.
 }
+\details{
+There is an experimental formatting feature implemented in this function.
+You can use \verb{\{.b text\}} for bold and \verb{\{.i text\}} formatting. Furthermore,
+\verb{\{.url www.url.com\}} formats the string as URL (i.e., enclosing URL in
+\code{<} and \code{>}, blue color and italic font style), while \verb{\{.pkg packagename\}}
+formats the text in blue color.
+}
 \examples{
 msg <- format_message("Much too long string for just one line, I guess!",
   line_length = 15
@@ -34,4 +41,12 @@ msg <- format_message("Much too long string for just one line, I guess!",
   line_length = 30
 )
 message(msg)
+
+# Caution, experimental!
+msg <- format_message(
+  "This is {.i italic}, visit {.url easystats.github.io/easystats}",
+  line_length = 30
+)
+message(msg)
+
 }

--- a/man/format_message.Rd
+++ b/man/format_message.Rd
@@ -23,15 +23,21 @@ can be accessed. By default, new lines are indented by two whitespace.
 }
 \details{
 There is an experimental formatting feature implemented in this function.
-You can use \verb{\{.b text\}} for bold and \verb{\{.i text\}} formatting. Furthermore,
-\verb{\{.url www.url.com\}} formats the string as URL (i.e., enclosing URL in
-\code{<} and \code{>}, blue color and italic font style), while \verb{\{.pkg packagename\}}
-formats the text in blue color. This features has some limitations:
-it's hard to detect the each line length for multiple lines when the string
-contains formatting tags. Thus, it can happen that lines are wrapped at an
-earlier length than expected. Furthermore, if you have multiple words in a
-format tag (\verb{\{.b one two three\}}), a line break might occur inside this tag,
-and the formatting no longer works (messing up the message-string).
+You can use following tags:
+\itemize{
+\item \verb{\{.b text\}} for bold formatting
+\item \verb{\{.i text\}} to use italic font style
+\item \verb{\{.url www.url.com\}} formats the string as URL (i.e., enclosing URL in
+\code{<} and \code{>}, blue color and italic font style)
+\item \verb{\{.pkg packagename\}} formats the text in blue color.
+}
+
+This features has some limitations: it's hard to detect the each line length
+for multiple lines when the string contains formatting tags. Thus, it can
+happen that lines are wrapped at an earlier length than expected. Furthermore,
+if you have multiple words in a format tag (\verb{\{.b one two three\}}), a line
+break might occur inside this tag, and the formatting no longer works
+(messing up the message-string).
 }
 \examples{
 msg <- format_message("Much too long string for just one line, I guess!",

--- a/man/format_message.Rd
+++ b/man/format_message.Rd
@@ -30,7 +30,7 @@ formats the text in blue color. This features has some limitations:
 it's hard to detect the each line length for multiple lines when the string
 contains formatting tags. Thus, it can happen that lines are wrapped at an
 earlier length than expected. Furthermore, if you have multiple words in a
-format tag (`{.b one two three}``), a line break might occur inside this tag,
+format tag (\verb{\{.b one two three\}}), a line break might occur inside this tag,
 and the formatting no longer works (messing up the message-string).
 }
 \examples{

--- a/man/format_message.Rd
+++ b/man/format_message.Rd
@@ -26,7 +26,12 @@ There is an experimental formatting feature implemented in this function.
 You can use \verb{\{.b text\}} for bold and \verb{\{.i text\}} formatting. Furthermore,
 \verb{\{.url www.url.com\}} formats the string as URL (i.e., enclosing URL in
 \code{<} and \code{>}, blue color and italic font style), while \verb{\{.pkg packagename\}}
-formats the text in blue color.
+formats the text in blue color. This features has some limitations:
+it's hard to detect the each line length for multiple lines when the string
+contains formatting tags. Thus, it can happen that lines are wrapped at an
+earlier length than expected. Furthermore, if you have multiple words in a
+format tag (`{.b one two three}``), a line break might occur inside this tag,
+and the formatting no longer works (messing up the message-string).
 }
 \examples{
 msg <- format_message("Much too long string for just one line, I guess!",
@@ -42,7 +47,7 @@ msg <- format_message("Much too long string for just one line, I guess!",
 )
 message(msg)
 
-# Caution, experimental!
+# Caution, experimental! See 'Details'
 msg <- format_message(
   "This is {.i italic}, visit {.url easystats.github.io/easystats}",
   line_length = 30

--- a/man/get_predicted.Rd
+++ b/man/get_predicted.Rd
@@ -83,7 +83,8 @@ second argument has to be a model).}
 \item{...}{Other argument to be passed, for instance to \code{get_predicted_ci()}.}
 
 \item{data}{An optional data frame in which to look for variables with which
-to predict. If omitted, the data used to fit the model is used. Visualization matrices can be generated using \code{\link[=get_datagrid]{get_datagrid()}}.}
+to predict. If omitted, the data used to fit the model is used. Visualization
+matrices can be generated using \code{\link[=get_datagrid]{get_datagrid()}}.}
 
 \item{predict}{string or \code{NULL}
 \itemize{

--- a/man/get_predicted_ci.Rd
+++ b/man/get_predicted_ci.Rd
@@ -33,7 +33,8 @@ second argument has to be a model).}
 \code{\link[=get_predicted]{get_predicted()}}).}
 
 \item{data}{An optional data frame in which to look for variables with which
-to predict. If omitted, the data used to fit the model is used. Visualization matrices can be generated using \code{\link[=get_datagrid]{get_datagrid()}}.}
+to predict. If omitted, the data used to fit the model is used. Visualization
+matrices can be generated using \code{\link[=get_datagrid]{get_datagrid()}}.}
 
 \item{se}{Numeric vector of standard error of predicted values. If \code{NULL},
 standard errors are calculated based on the variance-covariance matrix.}


### PR DESCRIPTION
This PR adds minor formatting options to `format_message()`:

- `{.b boldtext}`
- `{.i emphasizetext}`
- `{.url url.toweb.site}`
- `{.pkg easystats}`

Example:

```r
library(insight)
x <- "This is a very long string that allow {.b bold} formatting"
cat(format_message(x))
```

Limitations: it's hard to detect the "real" (without format tags) streng length for line breaks. Thus, it can happen that lines are wrapped at an earlier length than expected. Furthermore, if you have multiple words in a format tag (`{.b one two three}`), a line break might occur in this tag, and the formatting no longer works.
