### PR TITLE
Catch for interacted `fixest::i(f0, i.f2)`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,12 @@ Authors@R:
              family = "Hayes",
              role = c("rev"),
              email = "alexpghayes@gmail.com",
-             comment = c(ORCID = "0000-0002-4985-5160")))
+             comment = c(ORCID = "0000-0002-4985-5160")),
+      person(given = "Grant",
+             family = "McDermott",
+             role = c("ctb"),
+             email = "grantmcd@uoregon.edu",
+             comment = c(ORCID = "0000-0001-7883-8573")))
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: A tool to provide an easy, intuitive and consistent
     access to information contained in various R models, like model

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Fixed issue with column alignment in `export_table()` when the data frame 
   to print contained unicode-characters longer than 1 byte.
+* Correctly extract predictors for `fixest::i(f1, i.f2)` interactions (#649 by 
+  @grantmcdermott).
 
 # insight 0.18.4
 

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -165,7 +165,7 @@ find_predictors.fixest <- function(x, flatten = FALSE, ...) {
   conditional <- all.vars(stats::formula(x))
   conditional <- setdiff(conditional, c(instruments, cluster, find_response(x)))
   # Catch for interacted fixest::i(f0, i.f2)
-  if (any(grepl(", i.", x$fml))) {
+  if (any(grepl(", i.", x$fml, fixed = TRUE))) {
     conditional <- gsub("^i\\.", "", conditional)
   }
 

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -164,6 +164,10 @@ find_predictors.fixest <- function(x, flatten = FALSE, ...) {
 
   conditional <- all.vars(stats::formula(x))
   conditional <- setdiff(conditional, c(instruments, cluster, find_response(x)))
+  # Catch for interacted fixest::i(f0, i.f2)
+  if (any(grepl(", i.", x$fml))) {
+    conditional <- gsub("^i\\.", "", conditional)
+  }
 
   l <- compact_list(list(
     "conditional" = conditional,

--- a/tests/testthat/test-fixest.R
+++ b/tests/testthat/test-fixest.R
@@ -296,3 +296,18 @@ test_that("find_variables with interaction", {
   mod <- feols(mpg ~ 0 | carb | vs:cyl ~ am:cyl, data = mtcars)
   expect_warning(find_variables(mod), NA)
 })
+
+
+test_that("find_predictors with i(f1, i.f2) interaction", {
+  aq <- airquality
+  aq$week <- aq$Day %/% 7 + 1
+
+  mod <- feols(Ozone ~ i(Month, i.week), aq, notes = FALSE)
+  expect_equal(
+    find_predictors(mod),
+    list(
+      conditional = c("Month", "week")
+    ),
+    ignore_attr = TRUE
+  )
+})


### PR DESCRIPTION
First identified with the help of @vincentarelbundock at https://github.com/vincentarelbundock/marginaleffects/issues/484

Example of current behaviour (note the leading `i.` on "week):

``` r
aq = airquality
aq$week = aq$Day %/% 7 + 1

mod = fixest::feols(Ozone ~ i(Month, i.week), aq, notes = FALSE)

# i. prefix on week is wrong
insight::find_predictors(mod)
#> $conditional
#> [1] "Month"  "i.week"

# Impacts downstream functions... 
head(insight::get_predictors(mod))
#>   Month
#> 1     5
#> 2     5
#> 3     5
#> 4     5
#> 5     5
#> 6     5
```

With this little fix:

```r
devtools::load_all("~/Documents/Projects/insight")
#> ℹ Loading insight
insight::find_predictors(mod)
#> $conditional
#> [1] "Month" "week"
head(insight::get_predictors(mod))
#>   Month week
#> 1     5    1
#> 2     5    1
#> 3     5    1
#> 4     5    1
#> 5     5    1
#> 6     5    1
```