### PR TITLE
Improve performance of `object_has_rownames()` 

### DIFF
--- a/R/utils_object.R
+++ b/R/utils_object.R
@@ -84,5 +84,5 @@ object_has_rownames <- function(x) {
     stop("Only dataframe objects are allowed.", call. = FALSE)
   }
 
-  !identical(as.character(seq_len(nrow(x))), rownames(x))
+  !all(is.numeric(attributes(x)$row.names))
 }

--- a/tests/testthat/test-object_has_helpers.R
+++ b/tests/testthat/test-object_has_helpers.R
@@ -4,5 +4,6 @@ test_that("object_has_* helpers", {
   expect_equal(object_has_names(list("x" = 1, "y" = 2), c("x", "a")), c(TRUE, FALSE))
 
   expect_true(object_has_rownames(mtcars))
+  expect_false(object_has_rownames(iris))
   expect_error(object_has_rownames(list("x" = 1, "y" = 2)))
 })


### PR DESCRIPTION
``` r
# current 

object_has_rownames <- function(x) {
  if (!is.data.frame(x)) {
    stop("Only dataframe objects are allowed.", call. = FALSE)
  }
  
  !identical(as.character(seq_len(nrow(x))), rownames(x))
}

# new

new_object_has_rownames <- function(x) {
  if (!is.data.frame(x)) {
    stop("Only dataframe objects are allowed.", call. = FALSE)
  }
  
  !all(is.numeric(attributes(x)$row.names))
}


out <- list()
for (i in 1:100000) {
  out[[i]] <- iris
}

out <- data.table::rbindlist(out)
nrow(out)
#> [1] 15000000

bench::mark(
  old = object_has_rownames(out),
  new = new_object_has_rownames(out)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median   `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>       <dbl> <bch:byt>    <dbl>
#> 1 old           13.5s    13.5s      0.0739     484MB   0.0739
#> 2 new             1µs    1.6µs 359776.            0B   0
```

<sup>Created on 2022-09-29 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
