### PR TITLE
Fix `object_has_rownames()`

### DIFF
--- a/R/utils_object.R
+++ b/R/utils_object.R
@@ -84,5 +84,5 @@ object_has_rownames <- function(x) {
     stop("Only dataframe objects are allowed.", call. = FALSE)
   }
 
-  !all(is.numeric(attributes(x)$row.names))
+  !identical(attributes(x)$row.names, 1:nrow(x))
 }

--- a/R/utils_object.R
+++ b/R/utils_object.R
@@ -84,5 +84,5 @@ object_has_rownames <- function(x) {
     stop("Only dataframe objects are allowed.", call. = FALSE)
   }
 
-  !identical(attributes(x)$row.names, 1:nrow(x))
+  !identical(attributes(x)$row.names, seq_len(nrow(x)))
 }

--- a/tests/testthat/test-object_has_helpers.R
+++ b/tests/testthat/test-object_has_helpers.R
@@ -7,3 +7,8 @@ test_that("object_has_* helpers", {
   expect_false(object_has_rownames(iris))
   expect_error(object_has_rownames(list("x" = 1, "y" = 2)))
 })
+
+test_that("object_has_* helpers, additional test", {
+  skip_if_not_installed("psych")
+  expect_true(object_has_rownames(psych::bfi))
+})

--- a/tests/testthat/test-object_has_helpers.R
+++ b/tests/testthat/test-object_has_helpers.R
@@ -5,6 +5,7 @@ test_that("object_has_* helpers", {
 
   expect_true(object_has_rownames(mtcars))
   expect_false(object_has_rownames(iris))
+  expect_false(object_has_rownames(data.frame()))
   expect_error(object_has_rownames(list("x" = 1, "y" = 2)))
 })
 


### PR DESCRIPTION
Make `object_has_rownames()` stricter (but still more performant), cf #652 :
``` r
# current 

object_has_rownames <- function(x) {
  if (!is.data.frame(x)) {
    stop("Only dataframe objects are allowed.", call. = FALSE)
  }
  
  !identical(as.character(seq_len(nrow(x))), rownames(x))
}

# new

new_object_has_rownames <- function(x) {
  if (!is.data.frame(x)) {
    stop("Only dataframe objects are allowed.", call. = FALSE)
  }
  
  !identical(attributes(x)$row.names, 1:nrow(x))
}


out <- list()
for (i in 1:100000) {
  out[[i]] <- iris
}

out <- data.table::rbindlist(out)
nrow(out)
#> [1] 15000000

bench::mark(
  old = object_has_rownames(out),
  new = new_object_has_rownames(out)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 old           12.3s    12.3s    0.0814     484MB   0.0814
#> 2 new          44.8ms   53.2ms    6.77       114MB   1.35
```

<sup>Created on 2022-09-30 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

Is it ok for you @bwiernik? I added a test for `psych::bfi`