### PR TITLE
Allow to show stars only for specific column

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.18.4.5
+Version: 0.18.4.6
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,13 @@
   refer to particular effectsizes (like Phi, Omega or Epsilon) include the related unicode-character instead of the written name. This only works on Windows for
   R >= 4.2, and on OS X or Linux for R >= 4.0.
 
+* The `stars` argument in `format_table()` can now also be a character vector,
+  naming the columns that should include stars for significant values. This is
+  especially useful for Bayesian models, where we might have multiple columns
+  with significant values, e.g. `"BF"` for the Bayes factor or `"pd"` for the
+  probability of direction.
+
+
 * `get_df()` gets more `type` options to return different type of degrees of
   freedom (namely, `"wald"` and `"normal"`, and for mixed models, `"ml1"`,
   `"betwithin"`, `"satterthwaite"` and `"kenward-roger"`).

--- a/R/format_table.R
+++ b/R/format_table.R
@@ -625,10 +625,10 @@ format_table <- function(x,
                                   exact = TRUE) {
 
   # Specify stars for which column
-  if(is.character(stars)) {
+  if (is.character(stars)) {
     starlist <- list("BF" = FALSE, "log_BF" = FALSE, "pd" = FALSE)
     starlist[stars] <- TRUE
-  } else{
+  } else {
     starlist <- list("BF" = stars, "log_BF" = stars, "pd" = stars)
   }
 

--- a/R/format_table.R
+++ b/R/format_table.R
@@ -182,7 +182,7 @@ format_table <- function(x,
   # Bayesian ---
   x <- .format_bayes_columns(
     x,
-    stars,
+    stars = stars,
     rope_digits = rope_digits,
     zap_small = zap_small,
     ci_width = ci_width,
@@ -617,19 +617,28 @@ format_table <- function(x,
 
 
 .format_bayes_columns <- function(x,
-                                  stars,
+                                  stars = FALSE,
                                   rope_digits = 2,
                                   zap_small,
                                   ci_width = "auto",
                                   ci_brackets = TRUE,
                                   exact = TRUE) {
+
+  # Specify stars for which column
+  if(is.character(stars)) {
+    starlist <- list("BF" = FALSE, "log_BF" = FALSE, "pd" = FALSE)
+    starlist[stars] <- TRUE
+  } else{
+    starlist <- list("BF" = stars, "log_BF" = stars, "pd" = stars)
+  }
+
   # Indices
-  if ("BF" %in% names(x)) x$BF <- format_bf(x$BF, name = NULL, stars = stars, exact = exact)
+  if ("BF" %in% names(x)) x$BF <- format_bf(x$BF, name = NULL, stars = starlist[["BF"]], exact = exact)
   if ("log_BF" %in% names(x)) {
-    x$BF <- format_bf(exp(x$log_BF), name = NULL, stars = stars, exact = exact)
+    x$BF <- format_bf(exp(x$log_BF), name = NULL, stars = starlist[["log_BF"]], exact = exact)
     x$log_BF <- NULL
   }
-  if ("pd" %in% names(x)) x$pd <- format_pd(x$pd, name = NULL, stars = stars)
+  if ("pd" %in% names(x)) x$pd <- format_pd(x$pd, name = NULL, stars = starlist[["pd"]])
   if ("Rhat" %in% names(x)) x$Rhat <- format_value(x$Rhat, digits = 3)
   if ("ESS" %in% names(x)) x$ESS <- round(x$ESS)
 

--- a/man/format_table.Rd
+++ b/man/format_table.Rd
@@ -31,7 +31,14 @@ of the \strong{easystats}-packages. May also be a result from
 \item{pretty_names}{Return "pretty" (i.e. more human readable) parameter
 names.}
 
-\item{stars}{Add significance stars (e.g., p < .001***).}
+\item{stars}{If \code{TRUE}, add significance stars (e.g., \verb{p < .001***}). Can
+also be a character vector, naming the columns that should include stars
+for significant values. This is especially useful for Bayesian models,
+where we might have multiple columns with significant values, e.g. \code{BF}
+for the Bayes factor or \code{pd} for the probability of direction. In such
+cases, use \code{stars = c("pd", "BF")} to add stars to both columns, or
+\code{stars = "BF"} to only add stars to the Bayes factor and exclude the \code{pd}
+column. Currently, following columns are recognized: \code{"BF"}, \code{"pd"} and \code{"p"}.}
 
 \item{digits, ci_digits, p_digits, rope_digits, ic_digits}{Number of digits for
 rounding or significant figures. May also be \code{"signif"} to return significant

--- a/tests/testthat/test-format_table.R
+++ b/tests/testthat/test-format_table.R
@@ -1,0 +1,61 @@
+.runThisTest <- Sys.getenv("RunAllinsightTests") == "yes"
+
+if (requiet("testthat") && requiet("insight")) {
+
+  # test for bayesian models -----------------
+  if (.runThisTest && requiet("bayestestR")) {
+    m1 <- insight::download_model("stanreg_glm_1")
+    x <- as.data.frame(bayestestR::describe_posterior(m1, test = c("pd", "bf")))
+
+    test_that("format_table with stars bayes", {
+      out <- format_table(x)
+      expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
+      expect_equal(out$BF, c("67.60", "119.13"))
+      expect_equal(out$pd, c("99.98%", "100%"))
+
+      out <- format_table(x, stars = TRUE)
+      expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
+      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$pd, c("99.98%***", "100%***"))
+
+      out <- format_table(x, stars = c("pd", "BF"))
+      expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
+      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$pd, c("99.98%***", "100%***"))
+
+      out <- format_table(x, stars = "pd")
+      expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
+      expect_equal(out$BF, c("67.60", "119.13"))
+      expect_equal(out$pd, c("99.98%***", "100%***"))
+
+      out <- format_table(x, stars = "BF")
+      expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
+      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$pd, c("99.98%", "100%"))
+    })
+  }
+
+
+  # test for freq models -----------------
+  if (requiet("parameters")) {
+    x <- as.data.frame(model_parameters(lm(Sepal.Length ~ Species + Sepal.Width, data = iris)))
+
+    test_that("format_table with stars freq", {
+      out <- format_table(x)
+      expect_equal(colnames(out), c("Parameter", "Coefficient", "SE", "95% CI", "t(146)", "p"))
+      expect_equal(out$p, c("< .001", "< .001", "< .001", "< .001"))
+
+      out <- format_table(x, stars = TRUE)
+      expect_equal(out$p, c("< .001***", "< .001***", "< .001***", "< .001***"))
+
+      out <- format_table(x, stars = c("pd", "BF"))
+      expect_equal(out$p, c("< .001", "< .001", "< .001", "< .001"))
+
+      out <- format_table(x, stars = "pd")
+      expect_equal(out$p, c("< .001", "< .001", "< .001", "< .001"))
+
+      out <- format_table(x, stars = c("BF", "p"))
+      expect_equal(out$p, c("< .001***", "< .001***", "< .001***", "< .001***"))
+    })
+  }
+}

--- a/tests/testthat/test-format_table.R
+++ b/tests/testthat/test-format_table.R
@@ -5,36 +5,38 @@ if (requiet("testthat") && requiet("insight")) {
   # test for bayesian models -----------------
   if (.runThisTest && requiet("bayestestR")) {
     m1 <- insight::download_model("stanreg_glm_1")
+    set.seed(123)
     x <- as.data.frame(bayestestR::describe_posterior(m1, test = c("pd", "bf")))
 
     test_that("format_table with stars bayes", {
       out <- format_table(x)
       expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
-      expect_equal(out$BF, c("67.60", "119.13"))
+      expect_equal(out$BF, c("62.73", "114.21"))
       expect_equal(out$pd, c("99.98%", "100%"))
 
       out <- format_table(x, stars = TRUE)
       expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
-      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$BF, c("62.73***", "114.21***"))
       expect_equal(out$pd, c("99.98%***", "100%***"))
 
       out <- format_table(x, stars = c("pd", "BF"))
       expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
-      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$BF, c("62.73***", "114.21***"))
       expect_equal(out$pd, c("99.98%***", "100%***"))
 
       out <- format_table(x, stars = "pd")
       expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
-      expect_equal(out$BF, c("67.60", "119.13"))
+      expect_equal(out$BF, c("62.73", "114.21"))
       expect_equal(out$pd, c("99.98%***", "100%***"))
 
       out <- format_table(x, stars = "BF")
       expect_equal(colnames(out), c("Parameter", "Median", "95% CI", "pd", "Rhat", "ESS", "BF"))
-      expect_equal(out$BF, c("67.60***", "119.13***"))
+      expect_equal(out$BF, c("62.73***", "114.21***"))
       expect_equal(out$pd, c("99.98%", "100%"))
     })
   }
 
+dput(out$pd)
 
   # test for freq models -----------------
   if (requiet("parameters")) {

--- a/tests/testthat/test-format_table.R
+++ b/tests/testthat/test-format_table.R
@@ -36,8 +36,6 @@ if (requiet("testthat") && requiet("insight")) {
     })
   }
 
-dput(out$pd)
-
   # test for freq models -----------------
   if (requiet("parameters")) {
     x <- as.data.frame(model_parameters(lm(Sepal.Length ~ Species + Sepal.Width, data = iris)))


### PR DESCRIPTION
``` r
m <- brms::brm(mpg ~ wt, data=mtcars, prior = brms::set_prior("normal(0, 1)", class = "b"), refresh=0)
#> Compiling Stan program...
#> Start sampling
param <- parameters::parameters(m, test=c("pd", "BF"))
#> Warning: Bayes factors might not be precise.
#> For precise Bayes factors, sampling at least 40,000 posterior samples is recommended.

insight::format_table(param, stars="pd")
#>     Parameter   Component Median         95% CI      pd  Rhat     ESS       BF
#> 1 (Intercept) conditional  32.30 [27.68, 36.28] 100%*** 1.001 2272.00 1.73e+08
#> 2          wt conditional  -3.81 [-4.96, -2.39] 100%*** 1.000 2163.00 1.60e+03
#> 3       sigma       sigma   3.47 [ 2.65,  4.83] 100%*** 1.001 1779.00 4.36e+09
```

<sup>Created on 2022-10-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>
