### PR TITLE
fix issue 658 by reproducing formula function

### DIFF
--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -1196,7 +1196,14 @@ find_formula.sem <- function(x, verbose = TRUE, ...) {
 
 #' @export
 find_formula.lme <- function(x, verbose = TRUE, ...) {
-  fm <- eval(x$call$fixed)
+  env <- environment(x$terms)
+  fm <- x$terms
+  attributes(fm) <- list(class = "formula")
+  environment(fm) <- if(is.null(env)) {
+	  globalenv()
+  } else {
+	  env
+  }
   fmr <- eval(x$call$random)
   ## TODO this is an intermediate fix to return the correlation variables from lme-objects
   fcorr <- x$call$correlation

--- a/R/find_formula.R
+++ b/R/find_formula.R
@@ -1196,14 +1196,7 @@ find_formula.sem <- function(x, verbose = TRUE, ...) {
 
 #' @export
 find_formula.lme <- function(x, verbose = TRUE, ...) {
-  env <- environment(x$terms)
-  fm <- x$terms
-  attributes(fm) <- list(class = "formula")
-  environment(fm) <- if(is.null(env)) {
-	  globalenv()
-  } else {
-	  env
-  }
+  fm <- stats::formula(x$terms)
   fmr <- eval(x$call$random)
   ## TODO this is an intermediate fix to return the correlation variables from lme-objects
   fcorr <- x$call$correlation


### PR DESCRIPTION
Close issue #658. The idea, as told there, is to do `fm <- formula(x$terms)` instead of `fm <- eval(x$call$fixed) `, but this would need to include `importFrom("stats", formula)` in the NAMESPACE, and since there is no `importFrom` there, I assumed you prefer not use them. Therefore, instead of using `formula(....)`, I wrote the  code of `stats:::formula.terms` there.