### PR TITLE
Fixes easystats/performance#432 (missing outlier plot when scaling data)

### DIFF
--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -319,7 +319,23 @@ get_predicted.lm <- function(x,
   args <- .get_predicted_args(x, data = data, predict = predict, verbose = verbose, ...)
 
   predict_function <- function(x, data, ...) {
-    stats::predict(x, newdata = data, interval = "none", type = args$type, se.fit = FALSE, ...)
+    stats::predict(x, newdata = data, interval = "none",
+                   type = args$type, se.fit = FALSE, ...)
+  }
+
+  # 0. step: convert matrix variable types attributes to numeric, if necessary
+  dataClasses <- attributes(x[["terms"]])$dataClasses
+  if ("nmatrix.1" %in% dataClasses) {
+    length.dataClasses <- length(dataClasses)
+    names.dataClasses <- names(dataClasses)
+    attributes(x[["terms"]])$dataClasses <- setNames(
+      unlist(lapply(dataClasses, function(x) {
+        if (x == "nmatrix.1") {
+          "numeric"
+        } else {
+          x
+        }
+      })), names.dataClasses)
   }
 
   # 1. step: predictions

--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -328,7 +328,7 @@ get_predicted.lm <- function(x,
   if ("nmatrix.1" %in% dataClasses) {
     length.dataClasses <- length(dataClasses)
     names.dataClasses <- names(dataClasses)
-    attributes(x[["terms"]])$dataClasses <- setNames(
+    attributes(x[["terms"]])$dataClasses <- stats::setNames(
       unlist(lapply(dataClasses, function(x) {
         if (x == "nmatrix.1") {
           "numeric"


### PR DESCRIPTION
Fixes easystats/performance#432 (missing outlier plot when scaling data)

``` r
# Scale data
library(dplyr)
mtcars2 <- mtcars %>%
  mutate(across(everything(), scale))

# Create model
m2 <- lm(mpg ~ wt + cyl + gear + disp, data = mtcars2)

# Verify that it fails to plot outliers with current version
performance::check_model(m2)
```

![](https://i.imgur.com/cz4NSyo.png)

``` r
# Load library
devtools::load_all(".../forks/insight")

# Verify that it works with dev version
performance::check_model(m2)
```

![](https://i.imgur.com/DsmZOaA.png)

<sup>Created on 2022-10-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
