### PR TITLE
make at argument more intuitive

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.18.6
+Version: 0.18.6.1
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,14 @@
+# insight 0.18.7
+
+## Bug fixes
+
+* Fixed behaviour of the `at` argument in `get_datagrid()`.
+
 # insight 0.18.6
+
+## New supported models
+
+* Support the *logitr* package: `get_data()`, `find_variables()` and more.
 
 ## Bug fixes
 
@@ -11,8 +21,6 @@
 
 * Fixed issue with `iterations` argument in `get_predicted()` with _brms_
   models.
-
-* Support the *logitr* package: `get_data()`, `find_variables()` and more.
 
 # insight 0.18.5
 

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -210,10 +210,10 @@ get_datagrid.data.frame <- function(x,
     # if list, convert to character
     if (is.list(at)) {
       at <- unname(vapply(names(at), function(i) {
-        if (is.numeric(x[[i]])) {
-          paste0(i, "=c(", toString(x[[i]]), ")")
+        if (is.numeric(at[[i]])) {
+          paste0(i, "=c(", toString(at[[i]]), ")")
         } else {
-          paste0(i, "=c(", toString(sprintf("'%s'", x[[i]])), ")")
+          paste0(i, "=c(", toString(sprintf("'%s'", at[[i]])), ")")
         }
       }, character(1)))
     }

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -209,8 +209,8 @@ get_datagrid.data.frame <- function(x,
 
     # if list, convert to character
     if (is.list(at)) {
-      at <- unname(vapply(names(x), function(i) {
-        if (is.numeric(x[[i]])) {
+      at <- unname(vapply(names(at), function(i) {
+        if (is.numeric(at[[i]])) {
           paste0(i, "=c(", toString(x[[i]]), ")")
         } else {
           paste0(i, "=c(", toString(sprintf("'%s'", x[[i]])), ")")

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -210,7 +210,7 @@ get_datagrid.data.frame <- function(x,
     # if list, convert to character
     if (is.list(at)) {
       at <- unname(vapply(names(at), function(i) {
-        if (is.numeric(at[[i]])) {
+        if (is.numeric(x[[i]])) {
           paste0(i, "=c(", toString(x[[i]]), ")")
         } else {
           paste0(i, "=c(", toString(sprintf("'%s'", x[[i]])), ")")

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -211,9 +211,9 @@ get_datagrid.data.frame <- function(x,
     if (is.list(at)) {
       at <- unname(vapply(names(at), function(i) {
         if (is.numeric(at[[i]])) {
-          paste0(i, "=c(", toString(at[[i]]), ")")
+          paste0(i, " = c(", toString(at[[i]]), ")")
         } else {
-          paste0(i, "=c(", toString(sprintf("'%s'", at[[i]])), ")")
+          paste0(i, " = c(", toString(sprintf("'%s'", at[[i]])), ")")
         }
       }, character(1)))
     }

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -19,7 +19,7 @@
 #'   will use a range of length `length` (evenly spread from minimum to maximum)
 #'   and for character vectors, will use all unique values.
 #'   - a list of named elements, indicating focal predictors and their representative
-#'   values, e.g. `at = list(c(Sepal.Length = c(2, 4), Species = "setosa"))`.
+#'   values, e.g. `at = list(Sepal.Length = c(2, 4), Species = "setosa")`.
 #'   - a string with assignments, e.g. `at = "Sepal.Length = 2"` or
 #'   `at = c("Sepal.Length = 2", "Species = 'setosa'")` - note the usage of single
 #'   and double quotes to assign strings within strings.
@@ -207,6 +207,17 @@ get_datagrid.data.frame <- function(x,
 
     # Validate at argument ============================
 
+    # if list, convert to character
+    if (is.list(at)) {
+      at <- unname(vapply(names(x), function(i) {
+        if (is.numeric(x[[i]])) {
+          paste0(i, "=c(", toString(x[[i]]), ")")
+        } else {
+          paste0(i, "=c(", toString(sprintf("'%s'", x[[i]])), ")")
+        }
+      }, character(1)))
+    }
+
     if (all(at == "all")) {
       at <- colnames(x)
     }
@@ -237,61 +248,55 @@ get_datagrid.data.frame <- function(x,
 
     # Deal with targets =======================================================
 
-    if (is.character(at)) {
-      # Find eventual user-defined specifications for each target
-      specs <- do.call(rbind, lapply(at, .get_datagrid_clean_target, x = x))
-      specs$varname <- as.character(specs$varname) # make sure it's a string not fac
-      specs <- specs[!duplicated(specs$varname), ] # Drop duplicates
+    # Find eventual user-defined specifications for each target
+    specs <- do.call(rbind, lapply(at, .get_datagrid_clean_target, x = x))
+    specs$varname <- as.character(specs$varname) # make sure it's a string not fac
+    specs <- specs[!duplicated(specs$varname), ] # Drop duplicates
 
-      specs$is_factor <- sapply(x[specs$varname], function(x) is.factor(x) || is.character(x))
+    specs$is_factor <- sapply(x[specs$varname], function(x) is.factor(x) || is.character(x))
 
-      # Create target list of factors -----------------------------------------
-      facs <- list()
-      for (fac in specs[specs$is_factor == TRUE, "varname"]) {
-        facs[[fac]] <- get_datagrid(
-          x[[fac]],
-          at = specs[specs$varname == fac, "expression"]
+    # Create target list of factors -----------------------------------------
+    facs <- list()
+    for (fac in specs[specs$is_factor == TRUE, "varname"]) {
+      facs[[fac]] <- get_datagrid(
+        x[[fac]],
+        at = specs[specs$varname == fac, "expression"]
+      )
+    }
+
+    # Create target list of numerics ----------------------------------------
+    nums <- list()
+    numvars <- specs[specs$is_factor == FALSE, "varname"]
+    if (length(numvars)) {
+      # Sanitize 'length' argument
+      if (length(length) == 1) {
+        length <- rep(length, length(numvars))
+      } else if (length(length) != length(numvars)) {
+        format_error(
+          "The number of elements in `length` must match the number of numeric target variables (n = ", length(numvars), ")."
+        )
+      }
+      # Sanitize 'range' argument
+      if (length(range) == 1) {
+        range <- rep(range, length(numvars))
+      } else if (length(range) != length(numvars)) {
+        format_error(
+          "The number of elements in `range` must match the number of numeric target variables (n = ", length(numvars), ")."
         )
       }
 
-      # Create target list of numerics ----------------------------------------
-      nums <- list()
-      numvars <- specs[specs$is_factor == FALSE, "varname"]
-      if (length(numvars)) {
-        # Sanitize 'length' argument
-        if (length(length) == 1) {
-          length <- rep(length, length(numvars))
-        } else if (length(length) != length(numvars)) {
-          format_error(
-            "The number of elements in `length` must match the number of numeric target variables (n = ", length(numvars), ")."
-          )
-        }
-        # Sanitize 'range' argument
-        if (length(range) == 1) {
-          range <- rep(range, length(numvars))
-        } else if (length(range) != length(numvars)) {
-          format_error(
-            "The number of elements in `range` must match the number of numeric target variables (n = ", length(numvars), ")."
-          )
-        }
-
-        # Get datagrids
-        for (i in seq_along(numvars)) {
-          num <- numvars[i]
-          nums[[num]] <- get_datagrid(x[[num]],
-            at = specs[specs$varname == num, "expression"],
-            reference = reference[[num]],
-            length = length[i],
-            range = range[i],
-            is_first_predictor = specs$varname[1] == num,
-            ...
-          )
-        }
+      # Get datagrids
+      for (i in seq_along(numvars)) {
+        num <- numvars[i]
+        nums[[num]] <- get_datagrid(x[[num]],
+          at = specs[specs$varname == num, "expression"],
+          reference = reference[[num]],
+          length = length[i],
+          range = range[i],
+          is_first_predictor = specs$varname[1] == num,
+          ...
+        )
       }
-    } else if (is.list(at)) {
-      # we have a list as at-values
-      facs <- at[sapply(x[names(at)], is.factor)]
-      nums <- at[sapply(x[names(at)], is.numeric)]
     }
 
     # Assemble the two - the goal is to have two named lists, where variable

--- a/man/get_datagrid.Rd
+++ b/man/get_datagrid.Rd
@@ -61,7 +61,7 @@ of unique values. For factors, will use all levels, for numeric variables,
 will use a range of length \code{length} (evenly spread from minimum to maximum)
 and for character vectors, will use all unique values.
 \item a list of named elements, indicating focal predictors and their representative
-values, e.g. \code{at = list(c(Sepal.Length = c(2, 4), Species = "setosa"))}.
+values, e.g. \code{at = list(Sepal.Length = c(2, 4), Species = "setosa")}.
 \item a string with assignments, e.g. \code{at = "Sepal.Length = 2"} or
 \code{at = c("Sepal.Length = 2", "Species = 'setosa'")} - note the usage of single
 and double quotes to assign strings within strings.

--- a/tests/testthat/test-get_datagrid.R
+++ b/tests/testthat/test-get_datagrid.R
@@ -76,6 +76,17 @@ if (requiet("testthat") && requiet("insight") && getRversion() >= "4.0.0") {
     dg <- insight::get_datagrid(m, c("Species", "Petal.Width"))
     expect_equal(colnames(dg), c("Species", "Petal.Width", "Petal.Length"))
   })
+
+
+  # list-argument
+  test_that("get_datagrid - list-argument", {
+    at <- list(Sepal.Length = c(3, 5), Species = c("versicolor", "virginica"))
+    dg1 <- get_datagrid(iris, at = at)
+    at <- c("Sepal.Length = c(3, 5)", "Species = c('versicolor', 'virginica')")
+    dg2 <- get_datagrid(iris, at = at)
+
+    expect_equal(dg1, dg2, tolerance = 1e-4)
+  })
 }
 
 


### PR DESCRIPTION
The current behaviour of the `at` argument is confusing and not working as described in the docs.

``` r
library(insight)
# this is described in the docs, but doesn't work
get_datagrid(iris, at = list(c(Sepal.Length = c(2, 4), Species = "setosa")))
#> Error in at[sapply(x[names(at)], is.factor)]: invalid subscript type 'list'

# this looks strange and complicated
at <- c("Sepal.Length = c(3, 5)", "Species = c('versicolor', 'virginica')")
get_datagrid(iris, at = at)
#>   Sepal.Length    Species Sepal.Width Petal.Length Petal.Width
#> 1            3 versicolor    3.057333        3.758    1.199333
#> 2            5 versicolor    3.057333        3.758    1.199333
#> 3            3  virginica    3.057333        3.758    1.199333
#> 4            5  virginica    3.057333        3.758    1.199333
```

The new approach converts the passed list into a character vector:
`list(Sepal.Length = c(3, 5), Species = c("versicolor", "virginica"))` becomes ` c("Sepal.Length = c(3, 5)", "Species = c('versicolor', 'virginica')")`, which is then handled internally in the usual way.

``` r
library(insight)
# new proposal how list-argument should work
at <- list(Sepal.Length = c(3, 5), Species = c("versicolor", "virginica"))
get_datagrid(iris, at = at)
#>   Sepal.Length    Species Sepal.Width Petal.Length Petal.Width
#> 1            3 versicolor    3.057333        3.758    1.199333
#> 2            5 versicolor    3.057333        3.758    1.199333
#> 3            3  virginica    3.057333        3.758    1.199333
#> 4            5  virginica    3.057333        3.758    1.199333
```

So this PR basically makes `at` work with list-values, and uses a more intuitive way how the list has to look like.