### PR TITLE
Edgecase: when 'k' is a variable in GAM's s(), datagrid fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.18.6.2
+Version: 0.18.6.3
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 * Fixed behaviour of the `at` argument in `get_datagrid()`.
 
+* Fixed issue for accessing model data in `get_datagrid()` for some edge cases.
+
 # insight 0.18.6
 
 ## New supported models

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -912,10 +912,10 @@ get_datagrid.datagrid <- get_datagrid.visualisation_matrix
 
   # brute force - use all!
   if (is.null(data)) {
-    cols <- unique(
+    cols <- unique(c(
       find_terms(x, "all", flatten = TRUE),
       find_variables(x, "all", flatten = TRUE)
-    )
+    ))
     data <- tryCatch(
       {
         d <- get_data(x)

--- a/tests/testthat/test-get_datagrid.R
+++ b/tests/testthat/test-get_datagrid.R
@@ -182,6 +182,15 @@ if (requiet("testthat") && requiet("insight") && requiet("gamm4") && getRversion
     expect_equal(dim(get_datagrid(mod, include_random = FALSE, include_smooth = "fixed")), c(10, 2))
     expect_equal(dim(get_datagrid(mod, include_random = FALSE, include_smooth = FALSE)), c(10, 1))
 
+    # MGCV, splines with variables, see #678
+    data(mtcars)
+    mod <- mgcv::gam(mpg ~ s(wt, k = 3), data = mtcars)
+    out1 <- insight::get_datagrid(mod)
+    k <- 3
+    mod <- mgcv::gam(mpg ~ s(wt, k = k), data = mtcars)
+    out2 <- insight::get_datagrid(mod)
+    expect_equal(out1, out2)
+
 
     # STAN_GAMM4
     mod <- suppressWarnings(rstanarm::stan_gamm4(Petal.Length ~ Petal.Width + s(Sepal.Length), random = ~ (1 | Species), data = iris, iter = 100, chains = 2, refresh = 0))


### PR DESCRIPTION
Fixes #678