### PR TITLE
Fix variance for Tweedie with glmmTMB >= 1.1.5

### DIFF
--- a/R/compute_variances.R
+++ b/R/compute_variances.R
@@ -736,10 +736,11 @@
 # Get distributional variance for tweedie-family
 # ----------------------------------------------
 .variance_family_tweedie <- function(x, mu, phi) {
-  if("psi" %in% names(x$fit$par))
+  if ("psi" %in% names(x$fit$par)) {
      psi <- x$fit$par["psi"] # glmmmTMB >= 1.1.5
-  else
+  } else {
      psi <- x$fit$par["thetaf"]
+  }
   p <- unname(stats::plogis(psi) + 1)
   phi * mu^p
 }

--- a/R/compute_variances.R
+++ b/R/compute_variances.R
@@ -736,7 +736,11 @@
 # Get distributional variance for tweedie-family
 # ----------------------------------------------
 .variance_family_tweedie <- function(x, mu, phi) {
-  p <- unname(stats::plogis(x$fit$par["thetaf"]) + 1)
+  if("psi" %in% names(x$fit$par))
+     psi <- x$fit$par["psi"] # glmmmTMB >= 1.1.5
+  else
+     psi <- x$fit$par["thetaf"]
+  p <- unname(stats::plogis(psi) + 1)
   phi * mu^p
 }
 


### PR DESCRIPTION
`thetaf` was renamed to `psi` in glmmTMB 1.1.5 (https://github.com/glmmTMB/glmmTMB/pull/871). Keep supporting the old name just in case.