### PR TITLE
bugfix and test: get_data(additional_variables = TRUE)

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -129,8 +129,9 @@ get_data <- function(x, ...) {
         if (!is.null(model_call$subset)) {
           vars <- c(vars, all.vars(model_call$subset))
         }
+        vars <- unique(vars)
         if (!isTRUE(additional_variables)) {
-          dat <- dat[, intersect(unique(vars), colnames(dat)), drop = FALSE]
+          dat <- dat[, intersect(vars, colnames(dat)), drop = FALSE]
         }
       }
       # remove response for random effects
@@ -138,8 +139,15 @@ get_data <- function(x, ...) {
         resp <- find_response(x, combine = FALSE)
         dat <- dat[, setdiff(colnames(dat), resp), drop = FALSE]
       }
+
       # complete cases only, as in model frames, need to filter attributes
-      cc <- stats::complete.cases(dat)
+      # only use model variables in complete.cases()
+      if (!is.null(vars)) {
+        cc <- stats::complete.cases(dat[, intersect(vars, colnames(dat))])
+      } else {
+        cc <- stats::complete.cases(dat)
+      }
+
       if (!all(cc)) {
         # save original data, for attributes
         original_dat <- dat

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -13,10 +13,11 @@ test_that("lme4", {
 
 
 test_that("additional_variables = TRUE", {
-  dat <- mtcars
-  dat$qsec[1:10] <- NA
-  mod <- lm(mpg ~ hp, dat)
-  n1 <- nrow(dat)
+  k <- mtcars
+  k$qsec[1:10] <- NA
+  k <<- k
+  mod <- lm(mpg ~ hp, k)
+  n1 <- nrow(k)
   n2 <- nrow(insight::get_data(mod))
   n3 <- nrow(insight::get_data(mod, additional_variables = TRUE))
   expect_equal(n1, n2)

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -12,6 +12,18 @@ test_that("lme4", {
 })
 
 
+test_that("additional_variables = TRUE", {
+  dat <- mtcars
+  dat$qsec[1:10] <- NA
+  mod <- lm(mpg ~ hp, dat)
+  n1 <- nrow(dat)
+  n2 <- nrow(insight::get_data(mod))
+  n3 <- nrow(insight::get_data(mod, additional_variables = TRUE))
+  expect_equal(n1, n2)
+  expect_equal(n1, n3)
+})
+
+
 test_that("lm", {
   set.seed(1023)
   x <- rnorm(1000, sd = 4)


### PR DESCRIPTION
`complete.cases()` eliminated rows when missing values in non-model columns.