### PR TITLE
Fix `has_single_value` when only `NA` and `na.rm = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.18.8.12
+Version: 0.18.8.13
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,6 +38,9 @@
 
 * Fixes issue in `compact_list()`.
 
+* `has_single_value()` now returns `FALSE` when the object only has `NA` and 
+  `na.rm = TRUE`.
+
 # insight 0.18.8
 
 ## Bug fixes

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -141,5 +141,5 @@ safe_deparse_symbol <- function(x) {
 #' @export
 has_single_value <- function(x, na.rm = FALSE) {
   if (na.rm) x <- x[!is.na(x)]
-  !is.null(x) && isTRUE(all(x == x[1]))
+  !is.null(x) && length(x) > 0L && isTRUE(all(x == x[1]))
 }

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -45,40 +45,27 @@ test_that("n_unique() works with list", {
 
 test_that("has_single_value() works", {
   x <- c(1, 1)
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_true(has_single_value(x))
 
   x <- c("a", "a")
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_true(has_single_value(x))
 
   x <- factor(c("a", "a"))
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_true(has_single_value(x))
 
   x <- c(NA, 1)
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_false(has_single_value(x))
+  expect_true(has_single_value(x, na.rm = TRUE))
 
   x <- c(2, 1)
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_false(has_single_value(x))
 
   x <- c(NULL)
-  expect_identical(
-    length(unique(x)) == 1,
-    has_single_value(x)
-  )
+  expect_false(has_single_value(x))
+
+  x <- c(NA, NA)
+  expect_false(has_single_value(x))
+  expect_false(has_single_value(x, na.rm = TRUE))
 })
 
 test_that("safe_deparse_symbol() works", {


### PR DESCRIPTION
New behavior:
``` r
library(insight)
has_single_value(c(NA, NA), na.rm = TRUE)
#> [1] FALSE
```
