### PR TITLE
Small memory improvement for `trim_ws()` 

### DIFF
--- a/R/utilities.R
+++ b/R/utilities.R
@@ -46,7 +46,7 @@ trim_ws <- function(x, ...) {
 
 #' @export
 trim_ws.default <- function(x, ...) {
-  gsub("^\\s+|\\s+$", "", x)
+  gsub("^\\s+|\\s+$", "", x, perl = TRUE)
 }
 
 #' @rdname trim_ws


### PR DESCRIPTION
I realised in https://github.com/easystats/datawizard/pull/384 that `trim_ws()` uses a lot of memory compared to its base equivalent. Using `perl = TRUE` reduces it:

``` r
new_trim_ws <- function(x) {
  gsub("^\\s+|\\s+$", "", x, perl = TRUE)
}

test <- rep("  Some text. ", 10000)

bench::mark(
  base = trimws(test),
  old = insight::trim_ws(test),
  new = new_trim_ws(test),
  iterations = 1000
)
#> # A tibble: 3 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 base         4.99ms   5.44ms      168.  156.34KB    0.337
#> 2 old          6.06ms   6.68ms      134.    1.33MB    0.135
#> 3 new          3.97ms   4.72ms      179.   78.17KB    0.359
```

<sup>Created on 2023-03-19 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>