### PR TITLE
`str2lang()` available from `R 3.6`

### DIFF
--- a/R/backports.R
+++ b/R/backports.R
@@ -1,6 +1,0 @@
-.str2lang <- function(s) {
-  stopifnot(length(s) == 1L)
-  ex <- parse(text = s, keep.source = FALSE)
-  stopifnot(length(ex) == 1L)
-  ex[[1L]]
-}

--- a/R/find_response.R
+++ b/R/find_response.R
@@ -185,7 +185,7 @@ check_cbind <- function(resp, combine, model) {
     # "all.vars()" will take care of extracting the correct variables.
     resp_combined_string <- paste(resp, collapse = "+")
     # create an expression, so all.vars() works similar like for formulas
-    resp_combined <- tryCatch(all.vars(.str2lang(resp_combined_string)),
+    resp_combined <- tryCatch(all.vars(str2lang(resp_combined_string)),
       error = function(e) resp_combined_string
     )
     # if we do not want to combine, or if we just have one variable as

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -934,7 +934,7 @@ get_datagrid.datagrid <- get_datagrid.visualisation_matrix
   terms <- find_terms(x, flatten = TRUE)
   factors <- grepl("^(as\\.factor|as_factor|factor|as\\.ordered|ordered)\\((.*)\\)", terms)
   if (any(factors)) {
-    factor_expressions <- lapply(terms[factors], .str2lang)
+    factor_expressions <- lapply(terms[factors], str2lang)
     cleaned_terms <- vapply(factor_expressions, all.vars, character(1))
     for (i in cleaned_terms) {
       if (is.numeric(data[[i]])) {
@@ -945,7 +945,7 @@ get_datagrid.datagrid <- get_datagrid.visualisation_matrix
   }
   logicals <- grepl("^(as\\.logical|as_logical|logical)\\((.*)\\)", terms)
   if (any(logicals)) {
-    logical_expressions <- lapply(terms[logicals], .str2lang)
+    logical_expressions <- lapply(terms[logicals], str2lang)
     cleaned_terms <- vapply(logical_expressions, all.vars, character(1))
     for (i in cleaned_terms) {
       if (is.numeric(data[[i]])) {

--- a/R/null_model.R
+++ b/R/null_model.R
@@ -44,7 +44,7 @@ null_model <- function(model, verbose = TRUE, ...) {
     if (!is.null(offset_term)) {
       tryCatch(
         {
-          do.call(stats::update, list(model, ~1, offset = .str2lang(offset_term)))
+          do.call(stats::update, list(model, ~1, offset = str2lang(offset_term)))
         },
         error = function(e) {
           if (verbose) {
@@ -80,7 +80,7 @@ null_model <- function(model, verbose = TRUE, ...) {
     null.model <- tryCatch(
       {
         if (!is.null(offset_term)) {
-          do.call(stats::update, list(model, formula = nullform, offset = .str2lang(offset_term)))
+          do.call(stats::update, list(model, formula = nullform, offset = str2lang(offset_term)))
         } else {
           stats::update(model, nullform)
         }

--- a/R/utils_get_data.R
+++ b/R/utils_get_data.R
@@ -857,12 +857,12 @@
         # exeception: list for kruskal-wallis
         if (grepl("Kruskal-Wallis", x$method, fixed = TRUE) &&
           (length(data_name) == 1 && startsWith(data_name, "list("))) {
-          l <- eval(.str2lang(x$data.name))
+          l <- eval(str2lang(x$data.name))
           names(l) <- paste0("x", seq_along(l))
           return(l)
         }
 
-        data_call <- lapply(data_name, .str2lang)
+        data_call <- lapply(data_name, str2lang)
         columns <- lapply(data_call, eval)
 
         # detect which kind of tests we have -----------------


### PR DESCRIPTION
So remove the backported copy for R 3.5.