### PR TITLE
Include offset in get_data

### DIFF
--- a/R/utils_get_data.R
+++ b/R/utils_get_data.R
@@ -681,7 +681,7 @@
     all = find_variables(x, flatten = TRUE),
     random = find_random(x, split_nested = TRUE, flatten = TRUE)
   )
-  remain <- intersect(c(ft, find_weights(x)), cn)
+  remain <- intersect(c(ft, find_weights(x), find_offset(x)), cn)
 
   mf <- .safe(dat[, remain, drop = FALSE], dat)
   .prepare_get_data(x, mf, effects, verbose = verbose)


### PR DESCRIPTION
Small addition to make sure that any offset column is included as part of the `get_data` return.

I'm not sure how common the problem is, but it can occur when **fixest** models are called within another function and so the call environment is masked (thus requiring manual retrieval via the model frame). 

I first noticed it because offsets were not appearing as part of my **etwfe** package, which constructs a `fixest::feols()` call internally (https://github.com/grantmcdermott/etwfe/issues/28). But here's a much simpler MWE.

```r
feols2 = function(fml, data, ...) {
  fixest::feols(fml = fml, data = data, ...)
}

m1 = fixest::feols(mpg ~ hp, data = mtcars, offset = ~cyl) # native behaviour as sanity check
m2 =        feols2(mpg ~ hp, data = mtcars, offset = ~cyl)
```

Current behaviour (note that the "cyl" offset column is missing in the second instance).

``` r
insight::get_data(m1) |> head()
#>                    mpg  hp cyl
#> Mazda RX4         21.0 110   6
#> Mazda RX4 Wag     21.0 110   6
#> Datsun 710        22.8  93   4
#> Hornet 4 Drive    21.4 110   6
#> Hornet Sportabout 18.7 175   8
#> Valiant           18.1 105   6
insight::get_data(m2) |> head()
#> Warning: Could not recover model data from environment. Please make sure your
#>   data is available in your workspace.
#>   Trying to retrieve data from the model frame now.
#>                    mpg  hp
#> Mazda RX4         21.0 110 
#> Mazda RX4 Wag     21.0 110
#> Datsun 710        22.8  93
#> Hornet 4 Drive    21.4 110 
#> Hornet Sportabout 18.7 175
#> Valiant           18.1 105
```

After this PR:

``` r
insight::get_data(m1) |> head()
#>                    mpg  hp cyl
#> Mazda RX4         21.0 110   6
#> Mazda RX4 Wag     21.0 110   6
#> Datsun 710        22.8  93   4
#> Hornet 4 Drive    21.4 110   6
#> Hornet Sportabout 18.7 175   8
#> Valiant           18.1 105   6
insight::get_data(m2) |> head()
#> Warning: Could not recover model data from environment. Please make sure your
#>   data is available in your workspace.
#>   Trying to retrieve data from the model frame now.
#>                    mpg  hp cyl
#> Mazda RX4         21.0 110   6
#> Mazda RX4 Wag     21.0 110   6
#> Datsun 710        22.8  93   4
#> Hornet 4 Drive    21.4 110   6
#> Hornet Sportabout 18.7 175   8
#> Valiant           18.1 105   6
```