### PR TITLE
Fix #760, so `get_data()` can fetch from the correct environment, and add tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -57,7 +57,12 @@ Authors@R:
              family = "Thériault",
              role = "ctb",
              email = "remi.theriault@mail.mcgill.ca",
-             comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")))
+             comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")),
+      person(given = "Alex",
+             fammily = "Reinhart",
+             role = "ctb",
+             email = "areinhar@stat.cmu.edu",
+             comment = c(ORCID = "0000-0002-6658-514X")))
 Maintainer: Daniel Lüdecke <d.luedecke@uke.de>
 Description: A tool to provide an easy, intuitive and consistent
     access to information contained in various R models, like model

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -59,7 +59,7 @@ Authors@R:
              email = "remi.theriault@mail.mcgill.ca",
              comment = c(ORCID = "0000-0003-4315-6788", Twitter = "@rempsyc")),
       person(given = "Alex",
-             fammily = "Reinhart",
+             family = "Reinhart",
              role = "ctb",
              email = "areinhar@stat.cmu.edu",
              comment = c(ORCID = "0000-0002-6658-514X")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,13 @@
 
 * Fixed issue in `model_info()` for models of class `gamlss`.
 
+* Fixed problems preventing `get_data()` from locating data defined in
+  non-global environments.
+
+* Fixed issue in `get_predicted()` for variables of class numeric matrix created
+  by `scale()`, which were correctly handled only when `get_data()` failed to
+  find the data in the appropriate environment.
+
 # insight 0.19.1
 
 ## New supported models

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -221,11 +221,6 @@ get_data <- function(x, ...) {
                       enclos = NULL))
   }
 
-  # next try, parent frame
-  if (is.null(dat)) {
-    dat <- .safe(eval(model_call$data, envir = parent.frame()))
-  }
-
   # sanity check- if data frame is named like a function, e.g.
   # rep <- data.frame(...), we now have a function instead of the data
   # we then need to reset "dat" to NULL and search in the global env

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -209,12 +209,16 @@ get_data <- function(x, ...) {
     model_call[["data"]] <- as.name(data_name)
   }
 
-  # first, try environment of formula, see #666
-  dat <- .safe(eval(model_call$data, envir = environment(model_call$formula)))
+  # first, try environment of formula, see #666. set enclos = NULL so eval()
+  # does not fall back to parent frame when the environment is NULL, since we
+  # want to try that after checking the formula
+  dat <- .safe(eval(model_call$data, envir = environment(model_call$formula),
+                    enclos = NULL))
 
   # second, try to extract formula directly
   if (is.null(dat)) {
-    dat <- .safe(eval(model_call$data, envir = environment(find_formula(x))))
+    dat <- .safe(eval(model_call$data, envir = environment(find_formula(x)$conditional),
+                      enclos = NULL))
   }
 
   # next try, parent frame

--- a/R/get_predicted.R
+++ b/R/get_predicted.R
@@ -317,14 +317,16 @@ get_predicted.lm <- function(x,
     )
   }
 
-  # 0. step: convert matrix variable types attributes to numeric, if necessary
-  dataClasses <- attributes(x[["terms"]])$dataClasses
+  args <- .get_predicted_args(x, data = data, predict = predict, verbose = verbose, ...)
+
+  # 0. step: convert matrix variable types attributes to numeric, if necessary.
   # see https://github.com/easystats/insight/pull/671
+  dataClasses <- attributes(x[["terms"]])$dataClasses
   if ("nmatrix.1" %in% dataClasses) {
     dataClasses[dataClasses == "nmatrix.1"] <- "numeric"
     attributes(x$terms)$dataClasses <- dataClasses
     attributes(attributes(x$model)$terms)$dataClasses <- dataClasses
-    x$model[] <- lapply(x$model, function(x) {
+    args$data[] <- lapply(args$data, function(x) {
       if (all(class(x) == c("matrix", "array"))) { # nolint
         as.numeric(x)
       } else {
@@ -332,8 +334,6 @@ get_predicted.lm <- function(x,
       }
     })
   }
-
-  args <- .get_predicted_args(x, data = data, predict = predict, verbose = verbose, ...)
 
   # 1. step: predictions
   if (is.null(iterations)) {

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -183,7 +183,7 @@ test_that("mgcv", {
   skip_if_not_installed("mgcv")
 
   # mgcv::gam() deliberately does not keep its environment, so get_data() has to
-  # fall back to the parent frame. See
+  # fall back to the model frame. See
   # https://github.com/cran/mgcv/blob/a4e69cf44a49c84a41a42e90c86995a843733968/R/mgcv.r#L2156-L2159
   d <- iris
   d$NewFac <- rep(c(1, 2), length.out = 150)

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -1,5 +1,44 @@
 skip_on_os("mac")
 
+test_that("retrieve from same environment", {
+  foo <- data.frame(x = 1:10, y = 2:11)
+
+  fit <- lm(y ~ x, data = foo)
+
+  expect_no_warning(cols <- names(get_data(fit)))
+
+  expect_setequal(cols, c("x", "y"))
+})
+
+test_that("retrieve from correct environment", {
+  foo <- function() {
+    foo <- data.frame(x = 1:10, y = 2:11)
+
+    return(lm(y ~ x, data = foo))
+  }
+
+  # There should be no warning about "Could not recover model data from
+  # environment"
+  expect_no_warning(cols <- names(get_data(foo())))
+
+  expect_setequal(cols, c("x", "y"))
+})
+
+test_that("fetch from local, not global, environment", {
+  # See #760. If the local environment has a modified version of data also in
+  # the global environment, we should find the local version first, not the
+  # global version.
+
+  foo <- function() {
+    mtcars$cylinders <- factor(mtcars$cyl)
+
+    return(lm(mpg ~ cylinders + disp, data = mtcars))
+  }
+
+  expect_setequal(names(get_data(foo())),
+                  c("mpg", "disp", "cylinders"))
+})
+
 test_that("lme", {
   skip_if_not_installed("nlme")
   data("Orthodont", package = "nlme")
@@ -28,7 +67,7 @@ test_that("lme4", {
 test_that("additional_variables = TRUE", {
   k <- mtcars
   k$qsec[1:10] <- NA
-  k <<- k
+  k <- k
   mod <- lm(mpg ~ hp, k)
   n1 <- nrow(k)
   n2 <- nrow(insight::get_data(mod))
@@ -42,8 +81,8 @@ test_that("lm", {
   set.seed(1023)
   x <- rnorm(1000, sd = 4)
   y <- cos(x) + rnorm(1000)
-  # fails if we assign this locally
-  dat <<- data.frame(x, y)
+
+  dat <- data.frame(x, y)
   mod1 <- lm(y ~ x, data = dat)
   mod2 <- lm(y ~ cos(x), data = dat)
   expect_equal(get_data(mod1), get_data(mod2), ignore_attr = TRUE)
@@ -104,7 +143,7 @@ test_that("get_data include weights, even if ones", {
 
 
 test_that("lm with transformations", {
-  d <<- data.frame(
+  d <- data.frame(
     time = as.factor(c(1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 1, 2, 3, 4, 5)),
     group = c(1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2),
     sum = c(0, 5, 10, 15, 20, 0, 20, 25, 45, 50, 0, 5, 10, 15, 20, 0, 20, 25, 45, 50, 0, 5, 10, 15, 20, 0, 20, 25, 45, 50)
@@ -117,7 +156,7 @@ test_that("lm with transformations", {
 test_that("lm with poly and NA in response", {
   d <- iris
   d[1:25, "Sepal.Length"] <- NA
-  d2 <<- d
+  d2 <- d
   m <- lm(Sepal.Length ~ Species / poly(Petal.Width, 2), data = d2)
   expect_equal(get_data(m), iris[26:150, c("Sepal.Length", "Species", "Petal.Width")], ignore_attr = TRUE)
 })
@@ -185,7 +224,7 @@ test_that("get_data() log transform", {
   set.seed(123)
   x <- abs(rnorm(100, sd = 5)) + 5
   y <- exp(2 + 0.3 * x + rnorm(100, sd = 0.4))
-  dat <<- data.frame(y, x)
+  dat <- data.frame(y, x)
 
   mod <- lm(log(y) ~ log(x), data = dat)
   expect_equal(

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -39,6 +39,23 @@ test_that("fetch from local, not global, environment", {
                   c("mpg", "disp", "cylinders"))
 })
 
+test_that("retrieve from call formula environment", {
+  skip_if_not_installed("AER")
+
+  foo <- function() {
+    d <- data.frame(y = rnorm(100),
+                    x = rnorm(100))
+
+    # find_formula(fit)$conditional happens to not have an environment for tobit
+    # models, so get_data() should check environment(get_call(fit)$formula). See
+    # #666
+    return(AER::tobit(y ~ x, data = d, right = 1.5))
+  }
+
+  expect_setequal(names(get_data(foo())),
+                  c("x", "y"))
+})
+
 test_that("lme", {
   skip_if_not_installed("nlme")
   data("Orthodont", package = "nlme")

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -180,14 +180,20 @@ test_that("lm with poly and NA in response", {
 
 
 test_that("mgcv", {
-  ## NOTE check back every now and then and see if tests still work
-  skip("works interactively")
   skip_if_not_installed("mgcv")
+
+  # mgcv::gam() deliberately does not keep its environment, so get_data() has to
+  # fall back to the parent frame. See
+  # https://github.com/cran/mgcv/blob/a4e69cf44a49c84a41a42e90c86995a843733968/R/mgcv.r#L2156-L2159
   d <- iris
   d$NewFac <- rep(c(1, 2), length.out = 150)
   model <- mgcv::gam(Sepal.Length ~ s(Petal.Length, by = interaction(Species, NewFac)), data = d)
+
+  # There should be two warnings: One for failing to get the data from the
+  # environment, and one for not recovering interaction() accurately
+  expect_warning(expect_warning(model_data <- get_data(model)))
   expect_equal(
-    head(insight::get_data(model)),
+    head(model_data),
     head(d[c("Sepal.Length", "Petal.Length", "Species", "NewFac")]),
     ignore_attr = TRUE
   )

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -532,14 +532,25 @@ test_that("bugfix: used to return all zeros", {
 # Original Error: "variables were specified with different types from the fit"
 # Originates from using base R scale on dataframe (easystats/performance#432)
 test_that("bugfix: used to fail with matrix variables", {
-  mtcars2 <- mtcars
-  mtcars2$wt <- scale(mtcars2$wt)
-  m <- lm(mpg ~ wt + cyl + gear + disp, data = mtcars2)
-  pred <- get_predicted(m)
+  # put model data in a separate environment, to ensure we retrieve the correct
+  # data to fix its classes
+  foo <- function() {
+    mtcars2 <- mtcars
+    mtcars2$wt <- scale(mtcars2$wt)
+    return(lm(mpg ~ wt + cyl + gear + disp, data = mtcars2))
+  }
+  pred <- get_predicted(foo())
   expect_equal(class(pred), c("get_predicted", "numeric"))
   expect_true(all(attributes(attributes(attributes(
     pred
   )$data)$terms)$dataClasses == "numeric"))
+
+  # Now verify with the data in the same environment
+  mtcars2 <- mtcars
+  mtcars2$wt <- scale(mtcars2$wt)
+  m <- lm(mpg ~ wt + cyl + gear + disp, data = mtcars2)
+  expect_no_error(pred <- get_predicted(m))
+
   mtcars2$wt <- as.numeric(mtcars2$wt)
   m2 <- lm(mpg ~ wt + cyl + gear + disp, data = mtcars2)
   pred2 <- get_predicted(m2)


### PR DESCRIPTION
The commit messages should explain the issue, and I've added a comment explaining the `enclos` issue, since it's definitely not obvious.

I've also added tests for three cases:

* data is present in the local environment
* data is in a different environment
* data is in a different environment, and another object of the same name is in the parent environment

All of these fail without the fix. But it's worth adding more if you can think of additional cases, since this is definitely easy to mess up. Are there other cases you'd expect to cause problems?