### PR TITLE
Dangerous `get_data()` behavior with `fixest` models and name conflicts

### DIFF
--- a/R/get_data.R
+++ b/R/get_data.R
@@ -246,7 +246,7 @@ get_data <- function(x, ...) {
     dat_fixest <- .safe(eval(model_call$data, envir = parent.env(x$call_env)))
     # sanity check - does data from parent env. differ from current extracted
     # data? If so, use data from parent env.
-    if ((dim(dat_fixest)[1] == dim(dat)[1]) && (dim(dat_fixest)[2] != dim(dat)[2])) {
+    if (!is.null(dat_fixest) && (dim(dat_fixest)[1] == dim(dat)[1]) && (dim(dat_fixest)[2] != dim(dat)[2])) {
       dat <- dat_fixest
     }
   }

--- a/R/get_data.R
+++ b/R/get_data.R
@@ -239,6 +239,18 @@ get_data <- function(x, ...) {
     dat <- .safe(eval(model_call$data, envir = parent.env(x$call_env)))
   }
 
+  # special handling for fixest, see #767
+  if (inherits(x, "fixest") && !is.null(dat)) {
+    # when called from inside function, fixest seems to have a different
+    # environment that requires recovering from parent-environment
+    dat_fixest <- .safe(eval(model_call$data, envir = parent.env(x$call_env)))
+    # sanity check - does data from parent env. differ from current extracted
+    # data? If so, use data from parent env.
+    if ((dim(dat_fixest)[1] == dim(dat)[1]) && (dim(dat_fixest)[2] != dim(dat)[2])) {
+      dat <- dat_fixest
+    }
+  }
+
   if (!is.null(dat) && object_has_names(model_call, "subset")) {
     dat <- subset(dat, subset = eval(model_call$subset))
   }

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -413,7 +413,7 @@ test_that("get_data works for fixest inside functions", {
   }
   global_fixest <- fixest_wrapper(data = mtcars)
   data <- mtcars[, c("mpg", "disp")]
-  expect_names(
+  expect_named(
     get_data(global_fixest),
     c("mpg", "cylinders", "disp", "hp")
   )
@@ -422,7 +422,7 @@ test_that("get_data works for fixest inside functions", {
   d_cyl <- mtcars
   d_cyl$cylinders <- factor(d_cyl$cyl)
   global_fixest <- fixest::feglm(mpg ~ cylinders * disp + hp, data = d_cyl)
-  expect_names(
+  expect_named(
     get_data(global_fixest),
     c("mpg", "cylinders", "disp", "hp")
   )

--- a/tests/testthat/test-get_data.R
+++ b/tests/testthat/test-get_data.R
@@ -400,3 +400,30 @@ test_that("get_data colnames", {
   out <- get_data(m, additional_variables = TRUE)
   expect_true("qsec" %in% colnames(out))
 })
+
+
+test_that("get_data works for fixest inside functions", {
+  skip_if_not_installed("fixest")
+  data(mtcars)
+  # fit within function
+  fixest_wrapper <- function(data) {
+    data$cylinders <- factor(data$cyl)
+    fit <- fixest::feglm(mpg ~ cylinders * disp + hp, data = data)
+    return(fit)
+  }
+  global_fixest <- fixest_wrapper(data = mtcars)
+  data <- mtcars[, c("mpg", "disp")]
+  expect_names(
+    get_data(global_fixest),
+    c("mpg", "cylinders", "disp", "hp")
+  )
+
+  data(mtcars)
+  d_cyl <- mtcars
+  d_cyl$cylinders <- factor(d_cyl$cyl)
+  global_fixest <- fixest::feglm(mpg ~ cylinders * disp + hp, data = d_cyl)
+  expect_names(
+    get_data(global_fixest),
+    c("mpg", "cylinders", "disp", "hp")
+  )
+})


### PR DESCRIPTION
Fixes #767