### PR TITLE
Detect multivariate vgams/vglms

### DIFF
--- a/R/is_multivariate.R
+++ b/R/is_multivariate.R
@@ -59,5 +59,5 @@ is_multivariate <- function(x) {
     return(isTRUE(x@extra$multiple.responses))
   }
 
-  return(FALSE)
+  FALSE
 }

--- a/R/is_multivariate.R
+++ b/R/is_multivariate.R
@@ -54,5 +54,10 @@ is_multivariate <- function(x) {
     return(isTRUE(ncol(x$coefficients) > 1L))
   }
 
+  vgam_classes <- c("vglm", "vgam")
+  if (inherits(x, vgam_classes)) {
+    return(isTRUE(x@extra$multiple.responses))
+  }
+
   return(FALSE)
 }

--- a/R/model_info.R
+++ b/R/model_info.R
@@ -1092,6 +1092,7 @@ model_info.vgam <- function(x, ...) {
     fitfam = faminfo@vfamily[1],
     logit.link = any(.string_contains("logit", faminfo@blurb)),
     link.fun = link.fun,
+    multi.var = is_multivariate(x),
     ...
   )
 }

--- a/R/model_info.R
+++ b/R/model_info.R
@@ -39,7 +39,7 @@
 #' * `is_hurdle`: model has zero-inflation component and is a hurdle-model (truncated family distribution)
 #' * `is_dispersion`: model has dispersion component (not only dispersion _parameter_)
 #' * `is_mixed`: model is a mixed effects model (with random effects)
-#' * `is_multivariate`: model is a multivariate response model (currently only works for _brmsfit_ objects)
+#' * `is_multivariate`: model is a multivariate response model (currently only works for _brmsfit_ and _vglm/vgam_ objects)
 #' * `is_trial`: model response contains additional information about the trials
 #' * `is_bayesian`: model is a Bayesian model
 #' * `is_gam`: model is a generalized additive model

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -178,6 +178,7 @@ unstandardizing
 variates
 vectorized
 vgam
+vglm
 visualisation
 warmup
 warmups

--- a/man/model_info.Rd
+++ b/man/model_info.Rd
@@ -53,7 +53,7 @@ is returned, where all values starting with \code{is_} are logicals.
 \item \code{is_hurdle}: model has zero-inflation component and is a hurdle-model (truncated family distribution)
 \item \code{is_dispersion}: model has dispersion component (not only dispersion \emph{parameter})
 \item \code{is_mixed}: model is a mixed effects model (with random effects)
-\item \code{is_multivariate}: model is a multivariate response model (currently only works for \emph{brmsfit} objects)
+\item \code{is_multivariate}: model is a multivariate response model (currently only works for \emph{brmsfit} and \emph{vglm/vgam} objects)
 \item \code{is_trial}: model response contains additional information about the trials
 \item \code{is_bayesian}: model is a Bayesian model
 \item \code{is_gam}: model is a generalized additive model

--- a/tests/testthat/test-gam.R
+++ b/tests/testthat/test-gam.R
@@ -40,7 +40,7 @@ test_that("model_info", {
 
 test_that("n_parameters", {
   expect_identical(n_parameters(m1), 5L)
-  expect_identical(n_parameters(m1, component = "conditional"), 1)
+  expect_identical(n_parameters(m1, component = "conditional"), 1L)
 })
 
 test_that("clean_names", {

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -968,10 +968,27 @@ test_that("model_info, ordered beta", {
   out <- model_info(m)
   expect_true(out$is_orderedbeta)
   expect_identical(out$family, "ordbeta")
-  skip_on_cran()
-  out <- get_variance(m)
-  expect_equal(out$var.distribution, 1.44250604187634, tolerance = 1e-4)
 })
+
+
+withr::with_environment(
+  new.env(),
+  test_that("get_variance, ordered beta", {
+    skip_if_not_installed("glmmTMB", minimum_version = "1.1.8")
+    skip_if_not_installed("datawizard")
+    skip_if_not_installed("lme4")
+    skip_on_cran()
+    data(sleepstudy, package = "lme4")
+    sleepstudy$y <- datawizard::normalize(sleepstudy$Reaction)
+    m <- glmmTMB::glmmTMB(
+      y ~ Days + (Days | Subject),
+      data = sleepstudy,
+      family = glmmTMB::ordbeta()
+    )
+    out <- get_variance(m)
+    expect_equal(out$var.distribution, 1.44250604187634, tolerance = 1e-4)
+  })
+)
 
 
 test_that("model_info, recognize ZI even without ziformula", {

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -971,6 +971,23 @@ test_that("model_info, ordered beta", {
 })
 
 
+test_that("model_info, recognize ZI even without ziformula", {
+  skip_if_not_installed("glmmTMB")
+  data("fish", package = "insight")
+  fish$count <- fish$count + 1
+  m1 <- glmmTMB::glmmTMB(
+    count ~ child + camper + (1 | persons),
+    data = fish,
+    family = glmmTMB::truncated_nbinom1()
+  )
+  out <- model_info(m1)
+  expect_true(out$is_zero_inflated)
+  expect_true(out$is_hurdle)
+})
+
+
+skip_if_not_installed("withr")
+
 withr::with_environment(
   new.env(),
   test_that("get_variance, ordered beta", {
@@ -989,18 +1006,3 @@ withr::with_environment(
     expect_equal(out$var.distribution, 1.44250604187634, tolerance = 1e-4)
   })
 )
-
-
-test_that("model_info, recognize ZI even without ziformula", {
-  skip_if_not_installed("glmmTMB")
-  data("fish", package = "insight")
-  fish$count <- fish$count + 1
-  m1 <- glmmTMB::glmmTMB(
-    count ~ child + camper + (1 | persons),
-    data = fish,
-    family = glmmTMB::truncated_nbinom1()
-  )
-  out <- model_info(m1)
-  expect_true(out$is_zero_inflated)
-  expect_true(out$is_hurdle)
-})

--- a/tests/testthat/test-vgam.R
+++ b/tests/testthat/test-vgam.R
@@ -195,10 +195,11 @@ test_that("find_parameters", {
 
 test_that("is_multivariate", {
   expect_false(is_multivariate(m1))
-  expect_false(is_multivariate(m2))
+  expect_true(is_multivariate(m2))
 })
 
 test_that("find_statistic", {
   expect_identical(find_statistic(m1), "chi-squared statistic")
   expect_identical(find_statistic(m2), "chi-squared statistic")
 })
+

--- a/tests/testthat/test-vgam.R
+++ b/tests/testthat/test-vgam.R
@@ -48,10 +48,11 @@ test_that("find_response", {
 })
 
 test_that("get_response", {
-  expect_equal(get_response(m1), hunua$agaaus)
+  expect_identical(get_response(m1), hunua$agaaus)
   expect_equal(
     get_response(m2),
-    data.frame(agaaus = hunua$agaaus, kniexc = hunua$kniexc)
+    data.frame(agaaus = hunua$agaaus, kniexc = hunua$kniexc),
+    ignore_attr = TRUE
   )
 })
 
@@ -202,4 +203,3 @@ test_that("find_statistic", {
   expect_identical(find_statistic(m1), "chi-squared statistic")
   expect_identical(find_statistic(m2), "chi-squared statistic")
 })
-


### PR DESCRIPTION
I thought I might as well update this here so that the ggeffects function can use `model_info` for everything including checking for multivariate models. Works for both `is_multivariate` and `model_info`.

Updated one test which which expected `is_multivariate == FALSE`, I imagine as a placeholder - it has two outcome variables.

I figure this is a cleaner solution but let me know if you'd rather leave as is.

strengejacke/ggeffects#432