### PR TITLE
updates for glmmTMB changes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.19.9.1
+Version: 0.19.9.2
 Authors@R: 
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * Function like `find_variables()` or `clean_names()` now support multi-membership
   formulas for models from *brms*.
 
+* Updated tests to work with the latest changes in *glmmTMBM 1.1.9*.
+
 # insight 0.19.9
 
 ## New supported models

--- a/tests/testthat/test-get_variance.R
+++ b/tests/testthat/test-get_variance.R
@@ -3,12 +3,12 @@ skip_if_not_installed("lme4")
 data(sleepstudy, package = "lme4")
 data("Penicillin", package = "lme4")
 set.seed(12345)
-sleepstudy$grp <- sample(1:5, size = 180, replace = TRUE)
+sleepstudy$grp <- sample.int(5, size = 180, replace = TRUE)
 sleepstudy$subgrp <- NA
 for (i in 1:5) {
   filter_group <- sleepstudy$grp == i
   sleepstudy$subgrp[filter_group] <-
-    sample(1:30, size = sum(filter_group), replace = TRUE)
+    sample.int(30, size = sum(filter_group), replace = TRUE)
 }
 
 study_data <<- sleepstudy
@@ -286,7 +286,7 @@ test_that("get_variance-cat_random_slope", {
 
 data(sleepstudy, package = "lme4")
 set.seed(123)
-sleepstudy$Months <- sample(1:4, nrow(sleepstudy), TRUE)
+sleepstudy$Months <- sample.int(4, nrow(sleepstudy), TRUE)
 study_data3 <<- sleepstudy
 
 m2 <- lme4::lmer(Reaction ~ Days + (0 + Days | Subject), data = study_data3)
@@ -369,5 +369,5 @@ test_that("fixed effects variance for rank-deficient models, #765", {
     )
   })
   out <- get_variance_fixed(mod_TMB)
-  expect_equal(out, 627.03661, tolerance = 1e-4, ignore_attr = TRUE)
+  expect_equal(out, 627.04511567, tolerance = 1e-4, ignore_attr = TRUE)
 })

--- a/tests/testthat/test-get_variance.R
+++ b/tests/testthat/test-get_variance.R
@@ -364,7 +364,7 @@ test_that("fixed effects variance for rank-deficient models, #765", {
     mod_TMB <- glmmTMB::glmmTMB(
       z ~ x1 + x2 + x3 + x4 + (1 | re),
       data = dd,
-      start  = list(theta = 3),
+      start = list(theta = 3),
       control = glmmTMB::glmmTMBControl(rank_check = "adjust")
     )
   })

--- a/tests/testthat/test-get_variance.R
+++ b/tests/testthat/test-get_variance.R
@@ -364,6 +364,7 @@ test_that("fixed effects variance for rank-deficient models, #765", {
     mod_TMB <- glmmTMB::glmmTMB(
       z ~ x1 + x2 + x3 + x4 + (1 | re),
       data = dd,
+      start  = list(theta = 3),
       control = glmmTMB::glmmTMBControl(rank_check = "adjust")
     )
   })

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -617,7 +617,7 @@ test_that("get_data", {
   expect_null(get_data(m4, component = "disp", effects = "random", verbose = FALSE))
 })
 
-test_that("find_paramaters", {
+test_that("find_parameters", {
   expect_identical(
     find_parameters(m4),
     list(
@@ -685,7 +685,7 @@ test_that("find_paramaters", {
 })
 
 
-test_that("get_paramaters", {
+test_that("get_parameters", {
   expect_identical(nrow(get_parameters(m4)), 6L)
   expect_identical(
     colnames(get_parameters(m4)),
@@ -880,7 +880,8 @@ d2$sd <- "five"
 dat <- rbind(d1, d2)
 m0 <- glmmTMB::glmmTMB(x ~ sd + (1 | t), dispformula = ~sd, data = dat)
 
-test_that("get_paramaters", {
+
+test_that("get_parameters", {
   expect_identical(nrow(get_parameters(m0)), 4L)
   expect_identical(
     colnames(get_parameters(m0)),
@@ -897,7 +898,7 @@ test_that("get_paramaters", {
   )
   expect_equal(
     get_parameters(m0)$Estimate,
-    c(200.03431, -99.71491, 3.20287, 1.38648),
+    c(200.03431, -99.71491, 1.6014, 0.69323),
     tolerance = 1e-3
   )
   expect_identical(

--- a/tests/testthat/test-glmmTMB.R
+++ b/tests/testthat/test-glmmTMB.R
@@ -882,6 +882,7 @@ m0 <- glmmTMB::glmmTMB(x ~ sd + (1 | t), dispformula = ~sd, data = dat)
 
 
 test_that("get_parameters", {
+  skip_if_not_installed("glmmTMB", minimum_version = "1.1.9")
   expect_identical(nrow(get_parameters(m0)), 4L)
   expect_identical(
     colnames(get_parameters(m0)),


### PR DESCRIPTION
There are two changes here:

1. account for the fact that Gaussian dispersion is parameterized as log-SD rather than log-variance now
2. change starting value for `theta` to avoid a singular fit (caused by slight changes in numerical stability due to Gaussian reparameterization)

also some minor spelling corrections (sorry)

