### PR TITLE
get_varcov: better error message on bad vcov value

### DIFF
--- a/R/get_varcov_sandwich.R
+++ b/R/get_varcov_sandwich.R
@@ -108,6 +108,8 @@
       PL = "vcovPL",
       `kenward-roger` = "vcovAdj"
     )
+  } else {
+    vcov_fun_clean <- vcov_fun
   }
 
   # check if required package is available

--- a/R/get_varcov_sandwich.R
+++ b/R/get_varcov_sandwich.R
@@ -79,7 +79,7 @@
   ## TODO: what about Sattherthwaite? @vincentarelbundock
 
   if (!grepl("^(vcov|kernHAC|NeweyWest)", vcov_fun)) {
-    vcov_fun <- switch(vcov_fun,
+    vcov_fun_clean <- switch(vcov_fun,
       HC0 = ,
       HC1 = ,
       HC2 = ,
@@ -111,19 +111,23 @@
   }
 
   # check if required package is available
-  if (isTRUE(vcov_fun == "vcovAdj")) {
+  if (is.character(vcov_fun) && is.null(vcov_fun_clean)) {
+    format_error(sprintf("`%s` is not a recognized value for the `vcov` argument.", vcov_fun[1]))
+  } else if (isTRUE(vcov_fun_clean == "vcovAdj")) {
     check_if_installed("pbkrtest")
-    fun <- try(get(vcov_fun, asNamespace("pbkrtest")), silent = TRUE)
-  } else if (isTRUE(vcov_fun == "vcovCR")) {
+    fun <- try(get(vcov_fun_clean, asNamespace("pbkrtest")), silent = TRUE)
+  } else if (isTRUE(vcov_fun_clean == "vcovCR")) {
     check_if_installed("clubSandwich", reason = "to get cluster-robust standard errors")
-    fun <- try(get(vcov_fun, asNamespace("clubSandwich")), silent = TRUE)
+    fun <- try(get(vcov_fun_clean, asNamespace("clubSandwich")), silent = TRUE)
   } else {
     check_if_installed("sandwich", reason = "to get robust standard errors")
-    fun <- try(get(vcov_fun, asNamespace("sandwich")), silent = TRUE)
-    if (!is.function(fun)) {
-      format_error(sprintf("`%s` is not a function exported by the `sandwich` package.", vcov_fun))
+    fun <- try(get(vcov_fun_clean, asNamespace("sandwich")), silent = TRUE)
+    if (!is.function(fun) && is.character(vcov_fun)) {
+      format_error(sprintf("`%s` is not a function exported by the `sandwich` package.", vcov_fun[1]))
     }
   }
+
+  vcov_fun <- vcov_fun_clean
 
   # try with arguments
   .vcov <- try(do.call(fun, c(list(x), vcov_args)), silent = TRUE)

--- a/tests/testthat/test-get_varcov.R
+++ b/tests/testthat/test-get_varcov.R
@@ -82,3 +82,9 @@ test_that("error: ill-defined model", {
   m1 <- lm(y ~ 1, data = dd)
   expect_error(get_varcov(m1), regex = "Can't extract variance-covariance")
 })
+
+
+test_that("error: bad string", {
+  m <- lm(mpg ~ hp + factor(carb), data = mtcars)
+  expect_error(get_varcov(m, vcov = "bootstrap"), regexp = "not a recognized")
+})


### PR DESCRIPTION
Improves error messages when `vcov` argument is unrecognized. The previous error was unreadable because we were asking `sprintf` to insert a `NULL` value.