### PR TITLE
`display()` example loses linebreaks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.20.4.3
+Version: 0.20.4.4
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,10 @@
 * Arguments `na.rm` and `na_rm` are deprecated throughout the package's functions.
   Instead, use `remove_na`.
 
+## Bug fixes
+
+* Fixed rendering issue of the example in `?insight::display`.
+
 # insight 0.20.4
 
 ## New supported models

--- a/R/display.R
+++ b/R/display.R
@@ -14,7 +14,7 @@
 #' @return Depending on `format`, either an object of class `gt_tbl`
 #'   or a character vector of class `knitr_kable`.
 #'
-#' @examples
+#' @examplesIf requireNamespace("gt")
 #' display(iris[1:5, ], format = "html")
 #' @export
 display <- function(object, ...) {

--- a/R/display.R
+++ b/R/display.R
@@ -15,7 +15,7 @@
 #'   or a character vector of class `knitr_kable`.
 #'
 #' @examples
-#' display(iris[1:5, ])
+#' display(iris[1:5, ], format = "html")
 #' @export
 display <- function(object, ...) {
   UseMethod("display")

--- a/man/display.Rd
+++ b/man/display.Rd
@@ -40,5 +40,5 @@ Similar, \code{print_html()} is a shortcut for \code{display(format = "html")}.
 See the documentation for the specific objects' classes.
 }
 \examples{
-display(iris[1:5, ])
+display(iris[1:5, ], format = "html")
 }

--- a/man/display.Rd
+++ b/man/display.Rd
@@ -40,5 +40,7 @@ Similar, \code{print_html()} is a shortcut for \code{display(format = "html")}.
 See the documentation for the specific objects' classes.
 }
 \examples{
+\dontshow{if (requireNamespace("gt")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 display(iris[1:5, ], format = "html")
+\dontshow{\}) # examplesIf}
 }

--- a/man/trim_ws.Rd
+++ b/man/trim_ws.Rd
@@ -16,13 +16,13 @@ trim_ws(x, ...)
 
 n_unique(x, ...)
 
-\method{n_unique}{default}(x, remove_na = TRUE, na.rm, ...)
+\method{n_unique}{default}(x, remove_na = TRUE, na.rm = TRUE, ...)
 
 safe_deparse(x, ...)
 
 safe_deparse_symbol(x)
 
-has_single_value(x, remove_na = FALSE, na.rm, ...)
+has_single_value(x, remove_na = FALSE, na.rm = TRUE, ...)
 }
 \arguments{
 \item{x}{A (character) vector, or for some functions may also be a data frame.}


### PR DESCRIPTION
Fixes #931