### PR TITLE
Allow `export_table()` to split to more than 3 tables

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 0.99.0.1
+Version: 0.99.0.2
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -23,6 +23,9 @@
 * The function to calculate the corrections for likelihood-values when the
   response-variable is transformed is now exported as `get_likelihood_adjustment()`.
 
+* `export_table()` can now split tables into more than three tables when
+  `table_width` is used (formerly, the maximum number of split tables was three).
+
 ## Bug fix
 
 * `clean_parameters()` now uses the correct labels for the random effects

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -44,9 +44,10 @@
 #' @param table_width Numeric, or `"auto"`, indicating the width of the complete
 #'   table. If `table_width = "auto"` and the table is wider than the current
 #'   width (i.e. line length) of the console (or any other source for textual
-#'   output, like markdown files), the table is split into two parts. Else,
+#'   output, like markdown files), the table is split into multiple parts. Else,
 #'   if `table_width` is numeric and table rows are larger than `table_width`,
-#'   the table is split into two parts.
+#'   the table is split into multiple parts. For each new table, the first
+#'   column is repeated for better orientation.
 #' @param ... Currently not used.
 #' @inheritParams format_value
 #' @inheritParams get_data

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -584,7 +584,7 @@ print.insight_table <- function(x, ...) {
         # into the second table matrix
         if (i < ncol(.final_temp)) {
           final_extra[[e]] <- .final_temp[, 1:(i - 1), drop = FALSE]
-          final_extra[[e + 1]] <- .final_temp[, -(1:(i - 1)), drop = FALSE]
+          final_extra[[e + 1]] <- .final_temp[, c(1, i:ncol(.final_temp)), drop = FALSE]
         }
         e <- e + 1
       }

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -119,7 +119,7 @@ export_table <- function(x,
                          align = NULL,
                          by = NULL,
                          zap_small = FALSE,
-                         table_width = NULL,
+                         table_width = "auto",
                          verbose = TRUE,
                          ...) {
   # check args

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -681,7 +681,7 @@ print.insight_table <- function(x, ...) {
       # check whether user wants to have a "cross" char where vertical and
       # horizontal lines (from header line) cross.
       header_line <- .insert_cross(
-        paste0(rep_len(header, nchar(final_row, type = "width")), collapse = ""),
+        paste(rep_len(header, nchar(final_row, type = "width")), collapse = ""),
         cross, sep, final_row,
         is_last_row = row == nrow(final)
       )

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -584,7 +584,7 @@ print.insight_table <- function(x, ...) {
         # into the second table matrix
         if (i < ncol(.final_temp)) {
           final_extra[[e]] <- .final_temp[, 1:(i - 1), drop = FALSE]
-          final_extra[[e+1]] <- .final_temp[, -(1:(i - 1)), drop = FALSE]
+          final_extra[[e + 1]] <- .final_temp[, -(1:(i - 1)), drop = FALSE]
         }
         e <- e + 1
       }

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -565,20 +565,19 @@ print.insight_table <- function(x, ...) {
 
     # width of first table row of complete table. Currently, "final" is still
     # a matrix, so we need to paste the columns of the first row into a string
-    row_width <- nchar(paste0(final[1, ], collapse = sep), type = "width")
+    row_width <- nchar(paste(final[1, ], collapse = sep), type = "width")
 
     # possibly first split - all table columns longer than "line_width"
     # (i.e. first table row) go into a second string
     if (row_width > line_width) {
       final_extra <- list(final)
       e <- 1
-      while (nchar(paste0(tail(final_extra, 1)[[1]][1, ], collapse = sep), type = "width") > line_width &&
-             e <= length(final_extra)) {
+      while (nchar(paste(tail(final_extra, 1)[[1]][1, ], collapse = sep), type = "width") > line_width && e <= length(final_extra)) { # nolint
         .final_temp <- final_extra[[e]]
 
         i <- 1
         # determine how many columns fit into the first line
-        while (nchar(paste0(.final_temp[1, 1:i], collapse = sep), type = "width") < line_width) {
+        while (nchar(paste(.final_temp[1, 1:i], collapse = sep), type = "width") < line_width) {
           i <- i + 1
         }
         # copy first column, and all columns that did not fit into the first line

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -589,13 +589,13 @@ print.insight_table <- function(x, ...) {
         }
         e <- e + 1
       }
-    }
 
-    final <- final_extra[[1]]
-    if (length(final_extra) > 1) {
-      final_extra <- final_extra[-1]
-    } else {
-      final_extra <- NULL
+      final <- final_extra[[1]]
+      if (length(final_extra) > 1) {
+        final_extra <- final_extra[-1]
+      } else {
+        final_extra <- NULL
+      }
     }
   }
 

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -656,7 +656,7 @@ print.insight_table <- function(x, ...) {
   for (row in seq_len(nrow(final))) {
     # create a string for each row, where cells from original matrix are
     # separated by the separator char
-    final_row <- paste0(final[row, ], collapse = sep)
+    final_row <- paste(final[row, ], collapse = sep)
     # check if we have an empty row, and if so, fill with an
     # "empty line separator", if requested by user
     if (!is.null(empty_line) && !any(nzchar(trim_ws(final[row, ])))) {
@@ -667,7 +667,7 @@ print.insight_table <- function(x, ...) {
         # the empty line, which is just empty cells with separator char,
         # will now be replaced by the "empty line char", so we have a
         # clean separator line
-        paste0(rep_len(empty_line, nchar(final_row, type = "width")), collapse = ""),
+        paste(rep_len(empty_line, nchar(final_row, type = "width")), collapse = ""),
         cross, sep, final_row,
         is_last_row = row == nrow(final)
       )

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -572,7 +572,7 @@ print.insight_table <- function(x, ...) {
     if (row_width > line_width) {
       final_extra <- list(final)
       e <- 1
-      while (nchar(paste(tail(final_extra, 1)[[1]][1, ], collapse = sep), type = "width") > line_width && e <= length(final_extra)) { # nolint
+      while (nchar(paste(utils::tail(final_extra, 1)[[1]][1, ], collapse = sep), type = "width") > line_width && e <= length(final_extra)) { # nolint
         .final_temp <- final_extra[[e]]
 
         i <- 1

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -823,7 +823,7 @@ print.insight_table <- function(x, ...) {
   # go through all columns of the data frame
   for (i in 1:n_columns) {
     # create separator line for current column
-    tablecol <- paste(rep_len("-", column_width[i]), collapse = "")
+    tablecol <- paste0(rep_len("-", column_width[i]), collapse = "")
 
     # check if user-defined alignment is requested, and if so, extract
     # alignment direction and save to "align_char"
@@ -874,7 +874,7 @@ print.insight_table <- function(x, ...) {
   # Transform to character
   rows <- NULL
   for (row in seq_len(nrow(final))) {
-    final_row <- paste("|", paste(final[row, ], collapse = "|"), "|", collapse = "")
+    final_row <- paste0("|", paste0(final[row, ], collapse = "|"), "|", collapse = "")
     rows <- c(rows, final_row)
 
     # First row separation

--- a/R/export_table.R
+++ b/R/export_table.R
@@ -823,7 +823,7 @@ print.insight_table <- function(x, ...) {
   # go through all columns of the data frame
   for (i in 1:n_columns) {
     # create separator line for current column
-    tablecol <- paste0(rep_len("-", column_width[i]), collapse = "")
+    tablecol <- paste(rep_len("-", column_width[i]), collapse = "")
 
     # check if user-defined alignment is requested, and if so, extract
     # alignment direction and save to "align_char"
@@ -874,7 +874,7 @@ print.insight_table <- function(x, ...) {
   # Transform to character
   rows <- NULL
   for (row in seq_len(nrow(final))) {
-    final_row <- paste0("|", paste0(final[row, ], collapse = "|"), "|", collapse = "")
+    final_row <- paste("|", paste(final[row, ], collapse = "|"), "|", collapse = "")
     rows <- c(rows, final_row)
 
     # First row separation

--- a/man/export_table.Rd
+++ b/man/export_table.Rd
@@ -25,7 +25,7 @@ export_table(
   align = NULL,
   by = NULL,
   zap_small = FALSE,
-  table_width = NULL,
+  table_width = "auto",
   verbose = TRUE,
   ...
 )

--- a/man/export_table.Rd
+++ b/man/export_table.Rd
@@ -111,9 +111,10 @@ places than \code{digits} are printed in scientific notation.}
 \item{table_width}{Numeric, or \code{"auto"}, indicating the width of the complete
 table. If \code{table_width = "auto"} and the table is wider than the current
 width (i.e. line length) of the console (or any other source for textual
-output, like markdown files), the table is split into two parts. Else,
+output, like markdown files), the table is split into multiple parts. Else,
 if \code{table_width} is numeric and table rows are larger than \code{table_width},
-the table is split into two parts.}
+the table is split into multiple parts. For each new table, the first
+column is repeated for better orientation.}
 
 \item{verbose}{Toggle messages and warnings.}
 

--- a/tests/testthat/_snaps/windows/export_table.md
+++ b/tests/testthat/_snaps/windows/export_table.md
@@ -1,0 +1,95 @@
+# export_table, table_width
+
+    Code
+      print(out, table_width = 50)
+    Output
+      # Comparison of Model Performance Indices
+      
+      Name   |  Model | Chi2(24) | p (Chi2)
+      -------------------------------------
+      model1 | lavaan |   85.306 |   < .001
+      model2 | lavaan |   85.306 |   < .001
+      
+      Name   | Baseline(36) | p (Baseline) |   GFI
+      --------------------------------------------
+      model1 |      918.852 |       < .001 | 0.943
+      model2 |      918.852 |       < .001 | 0.943
+      
+      Name   |  AGFI |   NFI |  NNFI |   CFI | RMSEA
+      ----------------------------------------------
+      model1 | 0.894 | 0.907 | 0.896 | 0.931 | 0.092
+      model2 | 0.894 | 0.907 | 0.896 | 0.931 | 0.092
+      
+      Name   |    RMSEA  CI | p (RMSEA) |   RMR |  SRMR
+      -------------------------------------------------
+      model1 | [0.07, 0.11] |    < .001 | 0.082 | 0.065
+      model2 | [0.07, 0.11] |    < .001 | 0.082 | 0.065
+      
+      Name   |   RFI |  PNFI |   IFI |   RNI
+      --------------------------------------
+      model1 | 0.861 | 0.605 | 0.931 | 0.931
+      model2 | 0.861 | 0.605 | 0.931 | 0.931
+      
+      Name   | Loglikelihood |  AIC (weights)
+      ---------------------------------------
+      model1 |     -3737.745 | 7517.5 (0.500)
+      model2 |     -3737.745 | 7517.5 (0.500)
+      
+      Name   |  BIC (weights) | BIC_adjusted
+      --------------------------------------
+      model1 | 7595.3 (0.500) |     7528.739
+      model2 | 7595.3 (0.500) |     7528.739
+
+---
+
+    Code
+      print(tab, table_width = 80)
+    Output
+      Parameter                           |               lm1 |                  lm2
+      ------------------------------------------------------------------------------
+      (Intercept)                         | 5.01 (4.86, 5.15) |  3.68 ( 3.47,  3.89)
+      Species [versicolor]                | 0.93 (0.73, 1.13) | -1.60 (-1.98, -1.22)
+      Species [virginica]                 | 1.58 (1.38, 1.79) | -2.12 (-2.66, -1.58)
+      Petal Length                        |                   |  0.90 ( 0.78,  1.03)
+      Species [versicolor] × Petal Length |                   |                     
+      Species [virginica] × Petal Length  |                   |                     
+      Petal Width                         |                   |                     
+      ------------------------------------------------------------------------------
+      Observations                        |               150 |                  150
+      
+      Parameter                           |                  lm3
+      ----------------------------------------------------------
+      (Intercept)                         |  4.21 ( 3.41,  5.02)
+      Species [versicolor]                | -1.81 (-2.99, -0.62)
+      Species [virginica]                 | -3.15 (-4.41, -1.90)
+      Petal Length                        |  0.54 ( 0.00,  1.09)
+      Species [versicolor] × Petal Length |  0.29 (-0.30,  0.87)
+      Species [virginica] × Petal Length  |  0.45 (-0.12,  1.03)
+      Petal Width                         |                     
+      ----------------------------------------------------------
+      Observations                        |                  150
+      
+      Parameter                           |                  lm4
+      ----------------------------------------------------------
+      (Intercept)                         |  4.21 ( 3.41,  5.02)
+      Species [versicolor]                | -1.80 (-2.99, -0.62)
+      Species [virginica]                 | -3.19 (-4.50, -1.88)
+      Petal Length                        |  0.54 (-0.02,  1.09)
+      Species [versicolor] × Petal Length |  0.28 (-0.30,  0.87)
+      Species [virginica] × Petal Length  |  0.45 (-0.12,  1.03)
+      Petal Width                         |  0.03 (-0.28,  0.34)
+      ----------------------------------------------------------
+      Observations                        |                  150
+      
+      Parameter                           |                  lm5 |                  lm6
+      ---------------------------------------------------------------------------------
+      (Intercept)                         |  4.21 ( 3.41,  5.02) |  4.21 ( 3.41,  5.02)
+      Species [versicolor]                | -1.80 (-2.99, -0.62) | -1.80 (-2.99, -0.62)
+      Species [virginica]                 | -3.19 (-4.50, -1.88) | -3.19 (-4.50, -1.88)
+      Petal Length                        |  0.54 (-0.02,  1.09) |  0.54 (-0.02,  1.09)
+      Species [versicolor] × Petal Length |  0.28 (-0.30,  0.87) |  0.28 (-0.30,  0.87)
+      Species [virginica] × Petal Length  |  0.45 (-0.12,  1.03) |  0.45 (-0.12,  1.03)
+      Petal Width                         |  0.03 (-0.28,  0.34) |  0.03 (-0.28,  0.34)
+      ---------------------------------------------------------------------------------
+      Observations                        |                  150 |                  150
+

--- a/tests/testthat/test-export_table.R
+++ b/tests/testthat/test-export_table.R
@@ -100,3 +100,30 @@ test_that("export_table", {
     ignore_attr = TRUE
   )
 })
+
+
+test_that("export_table, table_width", {
+  skip_on_cran()
+  skip_if_not_installed("lavaan")
+  skip_if_not_installed("performance")
+  skip_if_not_installed("parameters")
+
+  data(HolzingerSwineford1939, package = "lavaan")
+  structure <- " visual  =~ x1 + x2 + x3
+                 textual =~ x4 + x5 + x6
+                 speed   =~ x7 + x8 + x9 "
+  model1 <- lavaan::cfa(structure, data = HolzingerSwineford1939)
+  model2 <- lavaan::cfa(structure, data = HolzingerSwineford1939)
+
+  out <- performance::compare_performance(model1, model2)
+  expect_snapshot(print(out, table_width = 50), variant = "windows")
+
+  data(iris)
+  lm1 <- lm(Sepal.Length ~ Species, data = iris)
+  lm2 <- lm(Sepal.Length ~ Species + Petal.Length, data = iris)
+  lm3 <- lm(Sepal.Length ~ Species * Petal.Length, data = iris)
+  lm6 <- lm5 <- lm4 <- lm(Sepal.Length ~ Species * Petal.Length + Petal.Width, data = iris)
+
+  tab <- parameters::compare_parameters(lm1, lm2, lm3, lm4, lm5, lm6)
+  expect_snapshot(print(tab, table_width = 80), variant = "windows")
+})


### PR DESCRIPTION
Closes #951

> It's not set to auto, because sometimes a horizontal scrollbar is better than a split table, when it's just one column too wide.

_Originally posted by @strengejacke in https://github.com/easystats/insight/issues/951#issuecomment-2447096914_

The current implementation will never make a split that leaves a single column table.

``` r
z <- mtcars[1,] |> 
  insight::export_table(table_width = NULL) |> 
  strsplit(split = "\n") |> _[[1]]

nchar(z[1], type = "width")
#> [1] 68

# output is too wide, but it will not split a single column
mtcars[1:5,] |> 
  insight::export_table(table_width = 67)
#>   mpg | cyl | disp |  hp | drat |   wt |  qsec | vs | am | gear | carb
#> ----------------------------------------------------------------------
#> 21.00 |   6 |  160 | 110 | 3.90 | 2.62 | 16.46 |  0 |  1 |    4 |    4
#> 21.00 |   6 |  160 | 110 | 3.90 | 2.88 | 17.02 |  0 |  1 |    4 |    4
#> 22.80 |   4 |  108 |  93 | 3.85 | 2.32 | 18.61 |  1 |  1 |    4 |    1
#> 21.40 |   6 |  258 | 110 | 3.08 | 3.21 | 19.44 |  1 |  0 |    3 |    1
#> 18.70 |   8 |  360 | 175 | 3.15 | 3.44 | 17.02 |  0 |  0 |    3 |    2
```

<sup>Created on 2024-10-30 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>


So I think it's safe to set `table_width = "auto"` as the default. WDYT?