### PR TITLE
format_value() should consider "options(OutDec=',')" for separator formatting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,9 @@
 * `export_table()` can now split tables into more than three tables when
   `table_width` is used (formerly, the maximum number of split tables was three).
 
+* `format_value()` gains a `decimal_point` argument, to change the decimal point
+  in output conversion.
+
 ## Bug fix
 
 * `clean_parameters()` now uses the correct labels for the random effects

--- a/R/format_value.R
+++ b/R/format_value.R
@@ -34,6 +34,8 @@
 #' @param style_negative  A string that determines the style of negative numbers.
 #'   May be `"hyphen"` (default), `"minus"` for a proper Unicode minus symbol or
 #'   `"parens"` to wrap the number in parentheses.
+#' @param decimal_point Character string containing a single character that
+#'   is used as decimal point in output conversions.
 #' @param ... Arguments passed to or from other methods.
 #'
 #'
@@ -44,11 +46,12 @@
 #' format_value(1.2)
 #' format_value(1.2012313)
 #' format_value(c(0.0045, 234, -23))
-#' format_value(c(0.0045, .12, .34))
-#' format_value(c(0.0045, .12, .34), as_percent = TRUE)
-#' format_value(c(0.0045, .12, .34), digits = "scientific")
-#' format_value(c(0.0045, .12, .34), digits = "scientific2")
-#' format_value(c(0.045, .12, .34), lead_zero = FALSE)
+#' format_value(c(0.0045, 0.12, 0.34))
+#' format_value(c(0.0045, 0.12, 0.34), as_percent = TRUE)
+#' format_value(c(0.0045, 0.12, 0.34), digits = "scientific")
+#' format_value(c(0.0045, 0.12, 0.34), digits = "scientific2")
+#' format_value(c(0.045, 0.12, 0.34), lead_zero = FALSE)
+#' format_value(c(0.0045, 0.12, 0.34), decimal_point = ",")
 #'
 #' # default
 #' format_value(c(0.0045, .123, .345))
@@ -80,6 +83,7 @@ format_value.data.frame <- function(x,
                                     lead_zero = TRUE,
                                     style_positive = "none",
                                     style_negative = "hyphen",
+                                    decimal_point = getOption("OutDec"),
                                     ...) {
   as.data.frame(sapply(
     x,
@@ -93,6 +97,7 @@ format_value.data.frame <- function(x,
     lead_zero = lead_zero,
     style_positive = style_positive,
     style_negative = style_negative,
+    decimal_point = decimal_point,
     simplify = FALSE
   ))
 }
@@ -110,6 +115,7 @@ format_value.numeric <- function(x,
                                  lead_zero = TRUE,
                                  style_positive = "none",
                                  style_negative = "hyphen",
+                                 decimal_point = getOption("OutDec"),
                                  ...) {
   # check input
   style_positive <- match.arg(style_positive, choices = c("none", "plus", "space"))
@@ -166,6 +172,11 @@ format_value.numeric <- function(x,
       out[negatives] <- gsub("-", "\u2212", out[negatives], fixed = TRUE)
     } else if (style_negative == "parens") {
       out[negatives] <- gsub("-(.*)", "\\(\\1\\)", out[negatives])
+    }
+
+    # decimal points
+    if (!is.null(decimal_point) && !identical(decimal_point, ".")) {
+      out <- gsub(".", decimal_point, out, fixed = TRUE)
     }
   }
 

--- a/man/format_value.Rd
+++ b/man/format_value.Rd
@@ -20,6 +20,7 @@ format_value(x, ...)
   lead_zero = TRUE,
   style_positive = "none",
   style_negative = "hyphen",
+  decimal_point = getOption("OutDec"),
   ...
 )
 
@@ -34,6 +35,7 @@ format_value(x, ...)
   lead_zero = TRUE,
   style_positive = "none",
   style_negative = "hyphen",
+  decimal_point = getOption("OutDec"),
   ...
 )
 
@@ -79,6 +81,9 @@ wide as a number or \code{+}.}
 \item{style_negative}{A string that determines the style of negative numbers.
 May be \code{"hyphen"} (default), \code{"minus"} for a proper Unicode minus symbol or
 \code{"parens"} to wrap the number in parentheses.}
+
+\item{decimal_point}{Character string containing a single character that
+is used as decimal point in output conversions.}
 }
 \value{
 A formatted string.
@@ -93,11 +98,12 @@ format_value(1.20)
 format_value(1.2)
 format_value(1.2012313)
 format_value(c(0.0045, 234, -23))
-format_value(c(0.0045, .12, .34))
-format_value(c(0.0045, .12, .34), as_percent = TRUE)
-format_value(c(0.0045, .12, .34), digits = "scientific")
-format_value(c(0.0045, .12, .34), digits = "scientific2")
-format_value(c(0.045, .12, .34), lead_zero = FALSE)
+format_value(c(0.0045, 0.12, 0.34))
+format_value(c(0.0045, 0.12, 0.34), as_percent = TRUE)
+format_value(c(0.0045, 0.12, 0.34), digits = "scientific")
+format_value(c(0.0045, 0.12, 0.34), digits = "scientific2")
+format_value(c(0.045, 0.12, 0.34), lead_zero = FALSE)
+format_value(c(0.0045, 0.12, 0.34), decimal_point = ",")
 
 # default
 format_value(c(0.0045, .123, .345))

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -4,6 +4,7 @@ test_that("format_value", {
   expect_identical(format_value(4.0, protect_integers = TRUE), "4")
   expect_identical(format_value(0, protect_integers = TRUE), "0")
   expect_identical(format_value(0), "0.00")
+  expect_identical(format_value(0, decimal_point = ","), "0,00")
   expect_identical(format_value(1234565789101112), "1.23e+15")
   expect_identical(format_value(1234565789101112, protect_integers = TRUE), "1234565789101112")
   expect_identical(format_value(0.0000000123), "1.23e-08")
@@ -11,6 +12,7 @@ test_that("format_value", {
   expect_identical(format_value(0.0000000123, digits = 8), "0.00000001")
   expect_identical(format_value(c(0.012, 0.45, -0.03), lead_zero = FALSE), c(".01", ".45", "-.03"))
   expect_identical(format_value(c(1.012, 0.45, -0.03), lead_zero = FALSE), c("1.01", ".45", "-.03"))
+  expect_identical(format_value(c(1.012, 0.45, -0.03), lead_zero = FALSE, decimal_point = ","), c("1,01", ",45", "-,03"))
   expect_identical(format_value(c(0.45, -0.03), style_positive = "plus"), c("+0.45", "-0.03"))
   expect_identical(format_value(c(0.45, -0.03), style_positive = "plus", lead_zero = FALSE), c("+.45", "-.03"))
   expect_equal(


### PR DESCRIPTION
Fixes #193