### PR TITLE
Reduce methods appearing in docs, to make docs clearer

### DIFF
--- a/R/find_parameters.R
+++ b/R/find_parameters.R
@@ -259,13 +259,9 @@ find_parameters.lavaan <- function(x, flatten = FALSE, ...) {
 
 # Panel models ----------------------------------------
 
-#' @rdname find_parameters
 #' @export
-find_parameters.pgmm <- function(x,
-                                 component = c("conditional", "all"),
-                                 flatten = FALSE,
-                                 ...) {
-  component <- match.arg(component)
+find_parameters.pgmm <- function(x, component = "conditional", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("conditional", "all"))
   s <- summary(x, robust = FALSE)
 
   l <- list(
@@ -807,13 +803,9 @@ find_parameters.mira <- function(x, flatten = FALSE, ...) {
 
 
 ## For questions or problems with this ask Fernando Miguez (femiguez@iastate.edu)
-#' @rdname find_parameters
 #' @export
-find_parameters.nls <- function(x,
-                                component = c("all", "conditional", "nonlinear"),
-                                flatten = FALSE,
-                                ...) {
-  component <- match.arg(component)
+find_parameters.nls <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("all", "conditional", "nonlinear"))
   f <- find_formula(x)
   elements <- .get_elements(effects = "fixed", component = component)
   f <- .prepare_predictors(x, f, elements)

--- a/R/find_parameters_bayesian.R
+++ b/R/find_parameters_bayesian.R
@@ -37,16 +37,19 @@
 #' - `mix`, mixture parameters (**brms** only)
 #' - `shiftprop`, shifted proportion parameters (**brms** only)
 #'
+#' Models of class **BGGM** additionally can return the elements `correlation`
+#' and `intercept`.
+#'
+#' Models of class **BFBayesFactor** additionally can return the element
+#' `extra`.
+#'
 #' @examples
 #' data(mtcars)
 #' m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 #' find_parameters(m)
 #' @export
-find_parameters.BGGM <- function(x,
-                                 component = c("correlation", "conditional", "intercept", "all"),
-                                 flatten = FALSE,
-                                 ...) {
-  component <- match.arg(component)
+find_parameters.BGGM <- function(x, component = "correlation", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("correlation", "conditional", "intercept", "all"))
   l <- switch(component,
     correlation = list(correlation = colnames(get_parameters(x, component = "correlation"))),
     conditional = list(conditional = colnames(get_parameters(x, component = "conditional"))),
@@ -71,16 +74,16 @@ find_parameters.BGGM <- function(x,
 #' @rdname find_parameters.BGGM
 #' @export
 find_parameters.BFBayesFactor <- function(x,
-                                          effects = c("all", "fixed", "random"),
-                                          component = c("all", "extra"),
+                                          effects = "all",
+                                          component = "all",
                                           flatten = FALSE,
                                           ...) {
   conditional <- NULL
   random <- NULL
   extra <- NULL
 
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(component, c("all", "extra"))
 
   if (.classify_BFBayesFactor(x) == "correlation") {
     conditional <- "rho"

--- a/R/find_parameters_gam.R
+++ b/R/find_parameters_gam.R
@@ -38,12 +38,8 @@ find_parameters.gamlss <- function(x, flatten = FALSE, ...) {
 }
 
 
-#' @rdname find_parameters.gamlss
 #' @export
-find_parameters.gam <- function(x,
-                                component = c("all", "conditional", "smooth_terms", "location"),
-                                flatten = FALSE,
-                                ...) {
+find_parameters.gam <- function(x, component = "all", flatten = FALSE, ...) {
   pars <- list(conditional = names(stats::coef(x)))
   pars$conditional <- text_remove_backticks(pars$conditional)
 
@@ -54,7 +50,7 @@ find_parameters.gam <- function(x,
 
   pars <- compact_list(pars)
 
-  component <- match.arg(component)
+  component <- validate_argument(component, c("all", "conditional", "smooth_terms", "location"))
   elements <- .get_elements(effects = "all", component = component)
   pars <- compact_list(pars[elements])
 
@@ -70,12 +66,9 @@ find_parameters.scam <- find_parameters.gam
 
 
 #' @export
-find_parameters.Gam <- function(x,
-                                component = c("all", "conditional", "smooth_terms", "location"),
-                                flatten = FALSE,
-                                ...) {
+find_parameters.Gam <- function(x, component = "all", flatten = FALSE, ...) {
   pars <- names(stats::coef(x))
-  component <- match.arg(component)
+  component <- validate_argument(component, c("all", "conditional", "smooth_terms", "location"))
 
   l <- compact_list(list(
     conditional = pars[.grep_non_smoothers(pars)],
@@ -96,13 +89,10 @@ find_parameters.vgam <- find_parameters.Gam
 
 
 #' @export
-find_parameters.gamm <- function(x,
-                                 component = c("all", "conditional", "smooth_terms", "location"),
-                                 flatten = FALSE,
-                                 ...) {
+find_parameters.gamm <- function(x, component = "all", flatten = FALSE, ...) {
   x <- x$gam
   class(x) <- c(class(x), c("glm", "lm"))
-  component <- match.arg(component)
+  component <- validate_argument(component, c("all", "conditional", "smooth_terms", "location"))
 
   l <- find_parameters.gam(x, component = component)
 
@@ -115,11 +105,8 @@ find_parameters.gamm <- function(x,
 
 
 #' @export
-find_parameters.cgam <- function(x,
-                                 component = c("all", "conditional", "smooth_terms", "location"),
-                                 flatten = FALSE,
-                                 ...) {
-  component <- match.arg(component)
+find_parameters.cgam <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("all", "conditional", "smooth_terms", "location"))
   sc <- summary(x)
 
   estimates <- sc$coefficients
@@ -164,10 +151,7 @@ find_parameters.selection <- find_parameters.SemiParBIV
 
 
 #' @export
-find_parameters.rqss <- function(x,
-                                 component = c("all", "conditional", "smooth_terms", "location"),
-                                 flatten = FALSE,
-                                 ...) {
+find_parameters.rqss <- function(x, component = "all", flatten = FALSE, ...) {
   sc <- summary(x)
 
   pars <- list(
@@ -178,7 +162,7 @@ find_parameters.rqss <- function(x,
   pars$conditional <- text_remove_backticks(pars$conditional)
   pars$smooth_terms <- text_remove_backticks(pars$smooth_terms)
 
-  component <- match.arg(component)
+  component <- validate_argument(component, c("all", "conditional", "smooth_terms", "location"))
   elements <- .get_elements(effects = "all", component)
   pars <- compact_list(pars[elements])
 

--- a/R/find_parameters_mfx.R
+++ b/R/find_parameters_mfx.R
@@ -35,17 +35,20 @@
 #' m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 #' find_parameters(m)
 #' @export
-find_parameters.betamfx <- function(x,
-                                    component = c("all", "conditional", "precision", "marginal", "location", "distributional", "auxiliary"),
-                                    flatten = FALSE,
-                                    ...) {
+find_parameters.betamfx <- function(x, component = "all", flatten = FALSE, ...) {
   pars <- list(
     marginal = text_remove_backticks(rownames(x$mfxest)),
     conditional = text_remove_backticks(names(x$fit$coefficients$mean)),
     precision = text_remove_backticks(names(x$fit$coefficients$precision))
   )
 
-  component <- match.arg(component)
+  component <- validate_argument(
+    component,
+    c(
+      "all", "conditional", "precision", "marginal", "location",
+      "distributional", "auxiliary"
+    )
+  )
   elements <- .get_elements(effects = "all", component = component)
   pars <- compact_list(pars[elements])
 
@@ -58,16 +61,16 @@ find_parameters.betamfx <- function(x,
 
 
 #' @export
-find_parameters.betaor <- function(x,
-                                   component = c("all", "conditional", "precision", "location", "distributional", "auxiliary"),
-                                   flatten = FALSE,
-                                   ...) {
+find_parameters.betaor <- function(x, component = "all", flatten = FALSE, ...) {
   pars <- list(
     conditional = text_remove_backticks(names(x$fit$coefficients$mean)),
     precision = text_remove_backticks(names(x$fit$coefficients$precision))
   )
 
-  component <- match.arg(component)
+  component <- validate_argument(
+    component,
+    c("all", "conditional", "precision", "location", "distributional", "auxiliary")
+  )
   elements <- .get_elements(effects = "all", component = component)
   pars <- compact_list(pars[elements])
 
@@ -81,14 +84,11 @@ find_parameters.betaor <- function(x,
 
 #' @rdname find_parameters.betamfx
 #' @export
-find_parameters.logitmfx <- function(x,
-                                     component = c("all", "conditional", "marginal", "location"),
-                                     flatten = FALSE,
-                                     ...) {
+find_parameters.logitmfx <- function(x, component = "all", flatten = FALSE, ...) {
   p <- text_remove_backticks(names(stats::coef(x$fit)))
   pars <- list(marginal = text_remove_backticks(rownames(x$mfxest)), conditional = p)
 
-  component <- match.arg(component)
+  component <- validate_argument(component, c("all", "conditional", "marginal", "location"))
   elements <- .get_elements(effects = "all", component = component)
   pars <- compact_list(pars[elements])
 

--- a/R/find_parameters_mixed.R
+++ b/R/find_parameters_mixed.R
@@ -41,13 +41,9 @@
 #' m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 #' find_parameters(m)
 #' @export
-find_parameters.glmmTMB <- function(x,
-                                    effects = c("all", "fixed", "random"),
-                                    component = c("all", "conditional", "zi", "zero_inflated", "dispersion"),
-                                    flatten = FALSE,
-                                    ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+find_parameters.glmmTMB <- function(x, effects = "all", component = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(component, c("all", "conditional", "zi", "zero_inflated", "dispersion"))
 
   # installed
   check_if_installed("lme4")
@@ -82,11 +78,7 @@ find_parameters.glmmTMB <- function(x,
 
 
 #' @export
-find_parameters.MixMod <- function(x,
-                                   effects = c("all", "fixed", "random"),
-                                   component = c("all", "conditional", "zi", "zero_inflated"),
-                                   flatten = FALSE,
-                                   ...) {
+find_parameters.MixMod <- function(x, effects = "all", component = "all", flatten = FALSE, ...) {
   # installed
   check_if_installed("lme4")
 
@@ -111,8 +103,9 @@ find_parameters.MixMod <- function(x,
 
   l <- lapply(l, text_remove_backticks)
 
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(component, c("all", "conditional", "zi", "zero_inflated"))
+
   elements <- .get_elements(effects = effects, component = component)
   l <- compact_list(l[elements])
 
@@ -124,18 +117,14 @@ find_parameters.MixMod <- function(x,
 }
 
 
-#' @rdname find_parameters.glmmTMB
 #' @export
-find_parameters.nlmerMod <- function(x,
-                                     effects = c("all", "fixed", "random"),
-                                     component = c("all", "conditional", "nonlinear"),
-                                     flatten = FALSE,
-                                     ...) {
+find_parameters.nlmerMod <- function(x, effects = "all", component = "all", flatten = FALSE, ...) {
   # installed
   check_if_installed("lme4")
 
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(component, c("all", "conditional", "nonlinear"))
+
   startvectors <- .get_startvector_from_env(x)
 
   if (effects == "fixed") {

--- a/R/find_parameters_mixed.R
+++ b/R/find_parameters_mixed.R
@@ -23,7 +23,8 @@
 #' @inheritParams find_predictors
 #'
 #' @return A list of parameter names. The returned list may have following
-#' elements:
+#' elements, usually returned based on the combination of the `effects` and
+#' `component` arguments:
 #'
 #' - `conditional`, the "fixed effects" part from the model.
 #' - `random`, the "random effects" part from the model.
@@ -410,11 +411,8 @@ find_parameters.glimML <- function(x, effects = "all", flatten = FALSE, ...) {
 
 
 #' @export
-find_parameters.mixor <- function(x,
-                                  effects = c("all", "fixed", "random"),
-                                  flatten = FALSE,
-                                  ...) {
-  effects <- match.arg(effects)
+find_parameters.mixor <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   coefs <- x$Model
   random_start <- grep("(\\(Intercept\\) \\(Intercept\\)|Random\\.\\(Intercept\\))", rownames(coefs))
   thresholds <- grep("Threshold\\d", rownames(coefs))

--- a/R/find_parameters_mixed.R
+++ b/R/find_parameters_mixed.R
@@ -144,14 +144,11 @@ find_parameters.nlmerMod <- function(x, effects = "all", component = "all", flat
 }
 
 
-#' @rdname find_parameters.glmmTMB
 #' @export
-find_parameters.hglm <- function(x,
-                                 effects = c("all", "fixed", "random"),
-                                 component = c("all", "conditional", "dispersion"),
-                                 flatten = FALSE,
-                                 ...) {
-  effects <- match.arg(effects)
+find_parameters.hglm <- function(x, effects = "all", component = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(component, c("all", "conditional", "dispersion"))
+
   fe <- x$fixef
   re <- x$ranef
 
@@ -173,13 +170,9 @@ find_parameters.hglm <- function(x,
 }
 
 
-#' @rdname find_parameters.glmmTMB
 #' @export
-find_parameters.merMod <- function(x,
-                                   effects = c("all", "fixed", "random"),
-                                   flatten = FALSE,
-                                   ...) {
-  effects <- match.arg(effects)
+find_parameters.merMod <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
 
   # installed
   check_if_installed("lme4")
@@ -207,21 +200,15 @@ find_parameters.rlmerMod <- find_parameters.merMod
 find_parameters.glmmadmb <- find_parameters.merMod
 
 #' @export
-find_parameters.merModList <- function(x,
-                                       effects = c("all", "fixed", "random"),
-                                       flatten = FALSE,
-                                       ...) {
-  effects <- match.arg(effects)
+find_parameters.merModList <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   find_parameters(x[[1]], effects = effects, flatten = flatten, ...)
 }
 
 
 #' @export
-find_parameters.svy2lme <- function(x,
-                                    effects = c("all", "fixed", "random"),
-                                    flatten = FALSE,
-                                    ...) {
-  effects <- match.arg(effects)
+find_parameters.svy2lme <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
 
   # we extract random effects only when really necessary, to save
   # computational time. In particular model with large sample and
@@ -241,11 +228,8 @@ find_parameters.svy2lme <- function(x,
 
 
 #' @export
-find_parameters.HLfit <- function(x,
-                                  effects = c("all", "fixed", "random"),
-                                  flatten = FALSE,
-                                  ...) {
-  effects <- match.arg(effects)
+find_parameters.HLfit <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
 
   # installed
   check_if_installed("lme4")
@@ -269,15 +253,12 @@ find_parameters.HLfit <- function(x,
 
 
 #' @export
-find_parameters.sem <- function(x,
-                                effects = c("all", "fixed", "random"),
-                                flatten = FALSE,
-                                ...) {
+find_parameters.sem <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+
   if (!.is_semLme(x)) {
     return(NULL)
   }
-
-  effects <- match.arg(effects)
 
   l <- compact_list(list(
     conditional = names(x$coef),
@@ -289,14 +270,10 @@ find_parameters.sem <- function(x,
 
 
 #' @export
-find_parameters.cpglmm <- function(x,
-                                   effects = c("all", "fixed", "random"),
-                                   flatten = FALSE,
-                                   ...) {
+find_parameters.cpglmm <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   # installed
   check_if_installed("cplm")
-
-  effects <- match.arg(effects)
 
   # we extract random effects only when really necessary, to save
   # computational time. In particular model with large sample and
@@ -316,13 +293,9 @@ find_parameters.cpglmm <- function(x,
 
 
 #' @export
-find_parameters.coxme <- function(x,
-                                  effects = c("all", "fixed", "random"),
-                                  flatten = FALSE,
-                                  ...) {
+find_parameters.coxme <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   check_if_installed("lme4")
-
-  effects <- match.arg(effects)
 
   if (effects == "fixed") {
     l <- list(conditional = names(lme4::fixef(x)))
@@ -342,14 +315,10 @@ find_parameters.coxme <- function(x,
 
 
 #' @export
-find_parameters.mixed <- function(x,
-                                  effects = c("all", "fixed", "random"),
-                                  flatten = FALSE,
-                                  ...) {
+find_parameters.mixed <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   # installed
   check_if_installed("lme4")
-
-  effects <- match.arg(effects)
 
   if (effects == "fixed") {
     l <- list(conditional = names(lme4::fixef(x$full_model)))
@@ -365,13 +334,9 @@ find_parameters.mixed <- function(x,
 
 
 #' @export
-find_parameters.lme <- function(x,
-                                effects = c("all", "fixed", "random"),
-                                flatten = FALSE,
-                                ...) {
+find_parameters.lme <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
   check_if_installed("lme4")
-
-  effects <- match.arg(effects)
 
   if (effects == "fixed") {
     l <- list(conditional = names(lme4::fixef(x)))
@@ -394,11 +359,9 @@ find_parameters.lme <- function(x,
 
 
 #' @export
-find_parameters.glmm <- function(x,
-                                 effects = c("all", "fixed", "random"),
-                                 flatten = FALSE,
-                                 ...) {
-  effects <- match.arg(effects)
+find_parameters.glmm <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+
   s <- summary(x)
   fe_params <- rownames(s$coefmat)
   re_params <- rownames(s$nucoefmat)
@@ -413,16 +376,14 @@ find_parameters.glmm <- function(x,
 
 
 #' @export
-find_parameters.BBmm <- function(x,
-                                 effects = c("all", "fixed", "random"),
-                                 flatten = FALSE,
-                                 ...) {
+find_parameters.BBmm <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+
   l <- compact_list(list(
     conditional = rownames(x$fixed.coef),
     random = x$namesRand
   ))
 
-  effects <- match.arg(effects)
   .filter_parameters(l,
     effects = effects,
     flatten = flatten,
@@ -432,16 +393,14 @@ find_parameters.BBmm <- function(x,
 
 
 #' @export
-find_parameters.glimML <- function(x,
-                                   effects = c("all", "fixed", "random"),
-                                   flatten = FALSE,
-                                   ...) {
+find_parameters.glimML <- function(x, effects = "all", flatten = FALSE, ...) {
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+
   l <- compact_list(list(
     conditional = names(x@fixed.param),
     random = names(x@random.param)
   ))
 
-  effects <- match.arg(effects)
   .filter_parameters(l,
     effects = effects,
     flatten = flatten,

--- a/R/find_parameters_other.R
+++ b/R/find_parameters_other.R
@@ -10,21 +10,21 @@
 #' @inheritParams find_predictors
 #'
 #' @return A list of parameter names. The returned list may have following
-#' elements:
+#' elements, usually requested via the `component` argument:
 #'
 #' - `conditional`, the "fixed effects" part from the model.
 #' - `full`, parameters from the full model.
+#' - `precision` for models of class `betareg`.
+#' - `survival` for model of class `mjoint`.
+#' - `extra` for models of class `glmx`.
 #'
 #' @examples
 #' data(mtcars)
 #' m <- lm(mpg ~ wt + cyl + vs, data = mtcars)
 #' find_parameters(m)
 #' @export
-find_parameters.averaging <- function(x,
-                                      component = c("conditional", "full"),
-                                      flatten = FALSE,
-                                      ...) {
-  component <- match.arg(component)
+find_parameters.averaging <- function(x, component = "conditional", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("conditional", "full"))
   cf <- stats::coef(x, full = component == "full")
   out <- list(conditional = text_remove_backticks(names(cf)))
 
@@ -36,13 +36,9 @@ find_parameters.averaging <- function(x,
 }
 
 
-#' @rdname find_parameters.averaging
 #' @export
-find_parameters.glmgee <- function(x,
-                                   component = c("all", "conditional", "dispersion"),
-                                   flatten = FALSE,
-                                   ...) {
-  component <- match.arg(component)
+find_parameters.glmgee <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("all", "conditional", "dispersion"))
 
   junk <- utils::capture.output({
     cs <- suppressWarnings(stats::coef(summary(x, corr = FALSE)))
@@ -64,13 +60,13 @@ find_parameters.glmgee <- function(x,
 }
 
 
-#' @rdname find_parameters.averaging
 #' @export
-find_parameters.betareg <- function(x,
-                                    component = c("all", "conditional", "precision", "location", "distributional", "auxiliary"),
-                                    flatten = FALSE,
-                                    ...) {
-  component <- match.arg(component)
+find_parameters.betareg <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(
+    component,
+    c("all", "conditional", "precision", "location", "distributional", "auxiliary")
+  )
+
   pars <- list(
     conditional = names(x$coefficients$mean),
     precision = names(x$coefficients$precision)
@@ -87,13 +83,12 @@ find_parameters.betareg <- function(x,
 }
 
 
-#' @rdname find_parameters.averaging
 #' @export
-find_parameters.DirichletRegModel <- function(x,
-                                              component = c("all", "conditional", "precision", "location", "distributional", "auxiliary"),
-                                              flatten = FALSE,
-                                              ...) {
-  component <- match.arg(component)
+find_parameters.DirichletRegModel <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(
+    component,
+    c("all", "conditional", "precision", "location", "distributional", "auxiliary")
+  )
   if (x$parametrization == "common") {
     pars <- list(conditional = names(unlist(stats::coef(x))))
   } else {
@@ -116,13 +111,9 @@ find_parameters.DirichletRegModel <- function(x,
 }
 
 
-#' @rdname find_parameters.averaging
 #' @export
-find_parameters.mjoint <- function(x,
-                                   component = c("all", "conditional", "survival"),
-                                   flatten = FALSE,
-                                   ...) {
-  component <- match.arg(component)
+find_parameters.mjoint <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("all", "conditional", "survival"))
   s <- summary(x)
 
   out <- list(
@@ -140,12 +131,9 @@ find_parameters.mjoint <- function(x,
 }
 
 
-#' @rdname find_parameters.averaging
 #' @export
-find_parameters.glmx <- function(x,
-                                 component = c("all", "conditional", "extra"),
-                                 flatten = FALSE,
-                                 ...) {
+find_parameters.glmx <- function(x, component = "all", flatten = FALSE, ...) {
+  component <- validate_argument(component, c("all", "conditional", "extra"))
   cf <- stats::coef(summary(x))
 
   out <- list(

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -1,23 +1,22 @@
 #' @title Find names of model predictors
 #' @name find_predictors
 #'
-#' @description Returns the names of the predictor variables for the
-#'    different parts of a model (like fixed or random effects, zero-inflated
-#'    component, ...). Unlike [`find_parameters()`], the names from
-#'    `find_predictors()` match the original variable names from the data
-#'    that was used to fit the model.
+#' @description Returns the names of the predictor variables for the different
+#' parts of a model (like fixed or random effects, zero-inflated component,
+#' ...). Unlike [`find_parameters()`], the names from `find_predictors()` match
+#' the original variable names from the data that was used to fit the model.
 #'
 #' @param x A fitted model.
 #' @param effects Should variables for fixed effects, random effects
-#'    or both be returned? Only applies to mixed models. May be abbreviated.
-#' @param component Indicates which model component shoild be returned. E.g.,
+#' or both be returned? Only applies to mixed models. May be abbreviated.
+#' @param component Indicates which model component should be returned. E.g.,
 #' should all predictor variables, predictor variables for the conditional
 #' model, the zero-inflated part of the model, the dispersion term or the
-#' instrumental variables be returned? See section _Model Components_ for futher
-#' details. May be abbreviated. Note that the *conditional* component is also
-#' called *count* or *mean* component, depending on the model.
-#' @param flatten Logical, if `TRUE`, the values are returned
-#'    as character vector, not as list. Duplicated values are removed.
+#' instrumental variables be returned? See section _Model Components_ for
+#' further details. May be abbreviated. Note that the *conditional* component is
+#' also called *count* or *mean* component, depending on the model.
+#' @param flatten Logical, if `TRUE`, the values are returned as character
+#' vector, not as list. Duplicated values are removed.
 #' @param verbose Toggle warnings.
 #' @param ... Currently not used.
 #'

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -241,17 +241,17 @@ find_predictors.bfsl <- function(x, flatten = FALSE, verbose = TRUE, ...) {
 }
 
 
-#' @rdname find_predictors
 #' @export
 find_predictors.afex_aov <- function(x,
-                                     effects = c("fixed", "random", "all"),
-                                     component = c("all", "conditional", "zi", "zero_inflated", "dispersion", "instruments", "correlation", "smooth_terms"), # nolint
+                                     effects = "fixed",
                                      flatten = FALSE,
                                      verbose = TRUE,
                                      ...) {
-  effects <- match.arg(effects)
+  effects <- validate_argument(effects, c("fixed", "random", "all"))
 
-  if (effects == "all") effects <- c("fixed", "random")
+  if (effects == "all") {
+    effects <- c("fixed", "random")
+  }
 
   l <- list(
     fixed = c(names(attr(x, "between")), names(attr(x, "within"))),

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -48,11 +48,12 @@
 #'
 #' **Special models**
 #'
-#' Some model classes also allow rather uncommon options. These are:#'
-#' - `mhurdle`, which also can have the components `"infrequent_purchase"`,
-#'   `"ip"`, and `"auxiliary"`.
-#' - `BGGM`, which also allows options `"correlation"` and `"intercept"`.
-#' - `BGBFBayesFactorGM`, which also allows the option `"extra"`.
+#' Some model classes also allow rather uncommon options. These are:
+#' - `mhurdle`: `"infrequent_purchase"`, `"ip"`, and `"auxiliary"`
+#' - `BGGM`: `"correlation"` and `"intercept"`
+#' - `BFBayesFactor`, `glmx`: `"extra"`
+#' - `averaging`:`"conditional"` and `"full"`
+#' - `mjoint`: `"survival"`
 #'
 #' @section Parameters, Variables, Predictors and Terms:
 #' There are four functions that return information about the variables in a

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -37,6 +37,10 @@
 #'   for models with zero-inflation or that can model the dispersion parameter.
 #' - `"instruments"`: for instrumental-variable or some fixed effects regression,
 #'   returns the instruments.
+#' - `"nonlinear"`: for non-linear models (like models of class `nlmerMod` or
+#'   `nls`), returns staring estimates for the nonlinear parameters.
+#' - `"correlation"`: for models with correlation-component, like `gls`, the
+#'   variables used to describe the correlation structure are returned.
 #' - `"location"`: returns location parameters such as `conditional`,
 #'   `zero_inflated`, `smooth_terms`, or `instruments` (everything that are
 #'   fixed or random effects - depending on the `effects` argument - but no
@@ -96,13 +100,19 @@ find_predictors <- function(x, ...) {
 #' @rdname find_predictors
 #' @export
 find_predictors.default <- function(x,
-                                    effects = c("fixed", "random", "all"),
-                                    component = c("all", "conditional", "zi", "zero_inflated", "dispersion", "instruments", "correlation", "smooth_terms"), # nolint
+                                    effects = "fixed",
+                                    component = "all",
                                     flatten = FALSE,
                                     verbose = TRUE,
                                     ...) {
-  effects <- match.arg(effects)
-  component <- match.arg(component)
+  effects <- validate_argument(effects, c("fixed", "random", "all"))
+  component <- validate_argument(
+    component,
+    c(
+      "all", "conditional", "zi", "zero_inflated", "dispersion", "instruments",
+      "correlation", "smooth_terms"
+    )
+  )
 
   f <- find_formula(x, verbose = verbose)
   is_mv <- is_multivariate(f)

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -10,13 +10,12 @@
 #' @param x A fitted model.
 #' @param effects Should variables for fixed effects, random effects
 #'    or both be returned? Only applies to mixed models. May be abbreviated.
-#' @param component Should all predictor variables, predictor variables for the
-#'   conditional model, the zero-inflated part of the model, the dispersion
-#'   term or the instrumental variables be returned? Applies to models
-#'   with zero-inflated and/or dispersion formula, or to models with instrumental
-#'   variable (so called fixed-effects regressions). May be abbreviated. Note that the
-#'   *conditional* component is also called *count* or *mean*
-#'   component, depending on the model.
+#' @param component Indicates which model component shoild be returned. E.g.,
+#' should all predictor variables, predictor variables for the conditional
+#' model, the zero-inflated part of the model, the dispersion term or the
+#' instrumental variables be returned? See section _Model Components_ for futher
+#' details. May be abbreviated. Note that the *conditional* component is also
+#' called *count* or *mean* component, depending on the model.
 #' @param flatten Logical, if `TRUE`, the values are returned
 #'    as character vector, not as list. Duplicated values are removed.
 #' @param verbose Toggle warnings.
@@ -47,6 +46,8 @@
 #'   auxiliary parameters).
 #' - `"distributional"` (or `"auxiliary"`): components like `sigma`, `dispersion`,
 #'   `beta` or `precision` (and other auxiliary parameters) are returned.
+#' - Special models are `mhurdle`, which also can have the components
+#'   `"infrequent_purchase"`, `"ip"`, and `"auxiliary"`.
 #'
 #' @section Parameters, Variables, Predictors and Terms:
 #' There are four functions that return information about the variables in a
@@ -74,7 +75,7 @@
 #'
 #' @return A list of character vectors that represent the name(s) of the
 #' predictor variables. Depending on the combination of the arguments
-#' `effects` and `component`, the returned list has following elements:
+#' `effects` and `component`, the returned list can have following elements:
 #'
 #' - `conditional`, the "fixed effects" terms from the model
 #' - `random`, the "random effects" terms from the model
@@ -87,6 +88,10 @@
 #'   the instrumental variables
 #' - `correlation`, for models with correlation-component like `gls`, the
 #'   variables used to describe the correlation structure
+#' - `nonlinear`, for non-linear models (like models of class `nlmerMod` or
+#'   `nls`), the staring estimates for the nonlinear parameters
+#' - `smooth_terms` returns smooth terms, only applies to GAMs (or similar
+#'   models that may contain smooth terms)
 #'
 #' @examples
 #' data(mtcars)

--- a/R/find_predictors.R
+++ b/R/find_predictors.R
@@ -46,8 +46,14 @@
 #'   auxiliary parameters).
 #' - `"distributional"` (or `"auxiliary"`): components like `sigma`, `dispersion`,
 #'   `beta` or `precision` (and other auxiliary parameters) are returned.
-#' - Special models are `mhurdle`, which also can have the components
-#'   `"infrequent_purchase"`, `"ip"`, and `"auxiliary"`.
+#'
+#' **Special models**
+#'
+#' Some model classes also allow rather uncommon options. These are:#'
+#' - `mhurdle`, which also can have the components `"infrequent_purchase"`,
+#'   `"ip"`, and `"auxiliary"`.
+#' - `BGGM`, which also allows options `"correlation"` and `"intercept"`.
+#' - `BGBFBayesFactorGM`, which also allows the option `"extra"`.
 #'
 #' @section Parameters, Variables, Predictors and Terms:
 #' There are four functions that return information about the variables in a

--- a/R/find_variables.R
+++ b/R/find_variables.R
@@ -61,8 +61,14 @@ find_variables <- function(x,
                            component = "all",
                            flatten = FALSE,
                            verbose = TRUE) {
-  effects <- match.arg(effects, choices = c("all", "fixed", "random"))
-  component <- match.arg(component, choices = c("all", "conditional", "zi", "zero_inflated", "dispersion", "instruments", "smooth_terms", "scale"))
+  effects <- validate_argument(effects, c("all", "fixed", "random"))
+  component <- validate_argument(
+    component,
+    c(
+      "all", "conditional", "zi", "zero_inflated", "dispersion",
+      "instruments", "smooth_terms", "scale"
+    )
+  )
 
   if (component %in% c("all", "conditional")) {
     resp <- find_response(x, combine = FALSE)

--- a/man/find_interactions.Rd
+++ b/man/find_interactions.Rd
@@ -13,13 +13,12 @@ find_interactions(
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}

--- a/man/find_interactions.Rd
+++ b/man/find_interactions.Rd
@@ -13,15 +13,15 @@ find_interactions(
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 }
 \value{
 A list of character vectors that represent the interaction terms.

--- a/man/find_parameters.BGGM.Rd
+++ b/man/find_parameters.BGGM.Rd
@@ -12,20 +12,9 @@
 \alias{find_parameters.sim.merMod}
 \title{Find names of model parameters from Bayesian models}
 \usage{
-\method{find_parameters}{BGGM}(
-  x,
-  component = c("correlation", "conditional", "intercept", "all"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{BGGM}(x, component = "correlation", flatten = FALSE, ...)
 
-\method{find_parameters}{BFBayesFactor}(
-  x,
-  effects = c("all", "fixed", "random"),
-  component = c("all", "extra"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{BFBayesFactor}(x, effects = "all", component = "all", flatten = FALSE, ...)
 
 \method{find_parameters}{MCMCglmm}(x, effects = c("all", "fixed", "random"), flatten = FALSE, ...)
 
@@ -136,6 +125,12 @@ parameters. These may be one of the following:
 \item \code{mix}, mixture parameters (\strong{brms} only)
 \item \code{shiftprop}, shifted proportion parameters (\strong{brms} only)
 }
+
+Models of class \strong{BGGM} additionally can return the elements \code{correlation}
+and \code{intercept}.
+
+Models of class \strong{BFBayesFactor} additionally can return the element
+\code{extra}.
 }
 \description{
 Returns the names of model parameters, like they typically

--- a/man/find_parameters.BGGM.Rd
+++ b/man/find_parameters.BGGM.Rd
@@ -85,13 +85,21 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
+\item{component}{Which type of parameters to return, such as parameters for the
 conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
+term, the instrumental variables or marginal effects be returned? Applies
+to models with zero-inflated and/or dispersion formula, or to models with
+instrumental variables (so called fixed-effects regressions), or models
+with marginal effects from \strong{mfx}. May be abbreviated. Note that the
 \emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+component, depending on the model. There are three convenient shortcuts:
+\code{component = "all"} returns all possible parameters.
+If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
+(everything that are fixed or random effects - depending on the \code{effects}
+argument - but no auxiliary parameters). For \code{component = "distributional"}
+(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
+\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}

--- a/man/find_parameters.BGGM.Rd
+++ b/man/find_parameters.BGGM.Rd
@@ -90,8 +90,8 @@ argument - but no auxiliary parameters). For \code{component = "distributional"}
 (or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 

--- a/man/find_parameters.Rd
+++ b/man/find_parameters.Rd
@@ -65,6 +65,8 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
 }
 }
 

--- a/man/find_parameters.Rd
+++ b/man/find_parameters.Rd
@@ -14,8 +14,8 @@ find_parameters(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{verbose}{Toggle messages and warnings.}
 }

--- a/man/find_parameters.Rd
+++ b/man/find_parameters.Rd
@@ -69,12 +69,13 @@ auxiliary parameters).
 
 \strong{Special models}
 
-Some model classes also allow rather uncommon options. These are:#'
+Some model classes also allow rather uncommon options. These are:
 \itemize{
-\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
-\code{"ip"}, and \code{"auxiliary"}.
-\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
-\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
+\item \code{mhurdle}: \code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}
+\item \code{BGGM}: \code{"correlation"} and \code{"intercept"}
+\item \code{BFBayesFactor}, \code{glmx}: \code{"extra"}
+\item \code{averaging}:\code{"conditional"} and \code{"full"}
+\item \code{mjoint}: \code{"survival"}
 }
 }
 

--- a/man/find_parameters.Rd
+++ b/man/find_parameters.Rd
@@ -3,22 +3,11 @@
 \name{find_parameters}
 \alias{find_parameters}
 \alias{find_parameters.default}
-\alias{find_parameters.pgmm}
-\alias{find_parameters.nls}
 \title{Find names of model parameters}
 \usage{
 find_parameters(x, ...)
 
 \method{find_parameters}{default}(x, flatten = FALSE, verbose = TRUE, ...)
-
-\method{find_parameters}{pgmm}(x, component = c("conditional", "all"), flatten = FALSE, ...)
-
-\method{find_parameters}{nls}(
-  x,
-  component = c("all", "conditional", "nonlinear"),
-  flatten = FALSE,
-  ...
-)
 }
 \arguments{
 \item{x}{A fitted model.}
@@ -29,14 +18,6 @@ find_parameters(x, ...)
 as character vector, not as list. Duplicated values are removed.}
 
 \item{verbose}{Toggle messages and warnings.}
-
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
 }
 \value{
 A list of parameter names. For simple models, only one list-element,
@@ -74,6 +55,10 @@ models that may contain smooth terms).
 for models with zero-inflation or that can model the dispersion parameter.
 \item \code{"instruments"}: for instrumental-variable or some fixed effects regression,
 returns the instruments.
+\item \code{"nonlinear"}: for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), returns staring estimates for the nonlinear parameters.
+\item \code{"correlation"}: for models with correlation-component, like \code{gls}, the
+variables used to describe the correlation structure are returned.
 \item \code{"location"}: returns location parameters such as \code{conditional},
 \code{zero_inflated}, \code{smooth_terms}, or \code{instruments} (everything that are
 fixed or random effects - depending on the \code{effects} argument - but no

--- a/man/find_parameters.Rd
+++ b/man/find_parameters.Rd
@@ -65,8 +65,16 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
-\item Special models are \code{mhurdle}, which also can have the components
-\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
+}
+
+\strong{Special models}
+
+Some model classes also allow rather uncommon options. These are:#'
+\itemize{
+\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
+\code{"ip"}, and \code{"auxiliary"}.
+\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
+\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
 }
 }
 

--- a/man/find_parameters.averaging.Rd
+++ b/man/find_parameters.averaging.Rd
@@ -2,51 +2,9 @@
 % Please edit documentation in R/find_parameters_other.R
 \name{find_parameters.averaging}
 \alias{find_parameters.averaging}
-\alias{find_parameters.glmgee}
-\alias{find_parameters.betareg}
-\alias{find_parameters.DirichletRegModel}
-\alias{find_parameters.mjoint}
-\alias{find_parameters.glmx}
 \title{Find model parameters from models with special components}
 \usage{
-\method{find_parameters}{averaging}(x, component = c("conditional", "full"), flatten = FALSE, ...)
-
-\method{find_parameters}{glmgee}(
-  x,
-  component = c("all", "conditional", "dispersion"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{betareg}(
-  x,
-  component = c("all", "conditional", "precision", "location", "distributional",
-    "auxiliary"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{DirichletRegModel}(
-  x,
-  component = c("all", "conditional", "precision", "location", "distributional",
-    "auxiliary"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{mjoint}(
-  x,
-  component = c("all", "conditional", "survival"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{glmx}(
-  x,
-  component = c("all", "conditional", "extra"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{averaging}(x, component = "conditional", flatten = FALSE, ...)
 }
 \arguments{
 \item{x}{A fitted model.}
@@ -74,10 +32,13 @@ vector, not as list. Duplicated values are removed.}
 }
 \value{
 A list of parameter names. The returned list may have following
-elements:
+elements, usually requested via the \code{component} argument:
 \itemize{
 \item \code{conditional}, the "fixed effects" part from the model.
 \item \code{full}, parameters from the full model.
+\item \code{precision} for models of class \code{betareg}.
+\item \code{survival} for model of class \code{mjoint}.
+\item \code{extra} for models of class \code{glmx}.
 }
 }
 \description{

--- a/man/find_parameters.averaging.Rd
+++ b/man/find_parameters.averaging.Rd
@@ -67,8 +67,8 @@ argument - but no auxiliary parameters). For \code{component = "distributional"}
 (or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 }

--- a/man/find_parameters.averaging.Rd
+++ b/man/find_parameters.averaging.Rd
@@ -51,13 +51,21 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
+\item{component}{Which type of parameters to return, such as parameters for the
 conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
+term, the instrumental variables or marginal effects be returned? Applies
+to models with zero-inflated and/or dispersion formula, or to models with
+instrumental variables (so called fixed-effects regressions), or models
+with marginal effects from \strong{mfx}. May be abbreviated. Note that the
 \emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+component, depending on the model. There are three convenient shortcuts:
+\code{component = "all"} returns all possible parameters.
+If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
+(everything that are fixed or random effects - depending on the \code{effects}
+argument - but no auxiliary parameters). For \code{component = "distributional"}
+(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
+\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}

--- a/man/find_parameters.betamfx.Rd
+++ b/man/find_parameters.betamfx.Rd
@@ -5,20 +5,9 @@
 \alias{find_parameters.logitmfx}
 \title{Find names of model parameters from marginal effects models}
 \usage{
-\method{find_parameters}{betamfx}(
-  x,
-  component = c("all", "conditional", "precision", "marginal", "location",
-    "distributional", "auxiliary"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{betamfx}(x, component = "all", flatten = FALSE, ...)
 
-\method{find_parameters}{logitmfx}(
-  x,
-  component = c("all", "conditional", "marginal", "location"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{logitmfx}(x, component = "all", flatten = FALSE, ...)
 }
 \arguments{
 \item{x}{A fitted model.}

--- a/man/find_parameters.betamfx.Rd
+++ b/man/find_parameters.betamfx.Rd
@@ -39,8 +39,8 @@ argument - but no auxiliary parameters). For \code{component = "distributional"}
 (or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 }

--- a/man/find_parameters.emmGrid.Rd
+++ b/man/find_parameters.emmGrid.Rd
@@ -9,8 +9,8 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{merge_parameters}{Logical, if \code{TRUE} and \code{x} has multiple columns for
 parameter names (like \code{emmGrid} objects may have), these are merged into a

--- a/man/find_parameters.gamlss.Rd
+++ b/man/find_parameters.gamlss.Rd
@@ -17,8 +17,8 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 

--- a/man/find_parameters.gamlss.Rd
+++ b/man/find_parameters.gamlss.Rd
@@ -2,17 +2,9 @@
 % Please edit documentation in R/find_parameters_gam.R
 \name{find_parameters.gamlss}
 \alias{find_parameters.gamlss}
-\alias{find_parameters.gam}
 \title{Find names of model parameters from generalized additive models}
 \usage{
 \method{find_parameters}{gamlss}(x, flatten = FALSE, ...)
-
-\method{find_parameters}{gam}(
-  x,
-  component = c("all", "conditional", "smooth_terms", "location"),
-  flatten = FALSE,
-  ...
-)
 }
 \arguments{
 \item{x}{A fitted model.}
@@ -21,22 +13,6 @@
 vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
-
-\item{component}{Which type of parameters to return, such as parameters for the
-conditional model, the zero-inflated part of the model, the dispersion
-term, the instrumental variables or marginal effects be returned? Applies
-to models with zero-inflated and/or dispersion formula, or to models with
-instrumental variables (so called fixed-effects regressions), or models
-with marginal effects from \strong{mfx}. May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model. There are three convenient shortcuts:
-\code{component = "all"} returns all possible parameters.
-If \code{component = "location"}, location parameters such as \code{conditional},
-\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
-(everything that are fixed or random effects - depending on the \code{effects}
-argument - but no auxiliary parameters). For \code{component = "distributional"}
-(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
-\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 }
 \value{
 A list of parameter names. The returned list may have following

--- a/man/find_parameters.gamlss.Rd
+++ b/man/find_parameters.gamlss.Rd
@@ -22,13 +22,21 @@ as character vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 
-\item{component}{Should all predictor variables, predictor variables for the
+\item{component}{Which type of parameters to return, such as parameters for the
 conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
+term, the instrumental variables or marginal effects be returned? Applies
+to models with zero-inflated and/or dispersion formula, or to models with
+instrumental variables (so called fixed-effects regressions), or models
+with marginal effects from \strong{mfx}. May be abbreviated. Note that the
 \emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+component, depending on the model. There are three convenient shortcuts:
+\code{component = "all"} returns all possible parameters.
+If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
+(everything that are fixed or random effects - depending on the \code{effects}
+argument - but no auxiliary parameters). For \code{component = "distributional"}
+(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
+\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 }
 \value{
 A list of parameter names. The returned list may have following

--- a/man/find_parameters.glmmTMB.Rd
+++ b/man/find_parameters.glmmTMB.Rd
@@ -25,8 +25,8 @@ but no auxiliary parameters). For \code{component = "distributional"} (or
 \code{"auxiliary"}), components like \code{sigma} or \code{dispersion} (and
 other auxiliary parameters) are returned.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 }

--- a/man/find_parameters.glmmTMB.Rd
+++ b/man/find_parameters.glmmTMB.Rd
@@ -32,7 +32,8 @@ vector, not as list. Duplicated values are removed.}
 }
 \value{
 A list of parameter names. The returned list may have following
-elements:
+elements, usually returned based on the combination of the \code{effects} and
+\code{component} arguments:
 \itemize{
 \item \code{conditional}, the "fixed effects" part from the model.
 \item \code{random}, the "random effects" part from the model.

--- a/man/find_parameters.glmmTMB.Rd
+++ b/man/find_parameters.glmmTMB.Rd
@@ -2,21 +2,9 @@
 % Please edit documentation in R/find_parameters_mixed.R
 \name{find_parameters.glmmTMB}
 \alias{find_parameters.glmmTMB}
-\alias{find_parameters.hglm}
-\alias{find_parameters.merMod}
 \title{Find names of model parameters from mixed models}
 \usage{
 \method{find_parameters}{glmmTMB}(x, effects = "all", component = "all", flatten = FALSE, ...)
-
-\method{find_parameters}{hglm}(
-  x,
-  effects = c("all", "fixed", "random"),
-  component = c("all", "conditional", "dispersion"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{merMod}(x, effects = c("all", "fixed", "random"), flatten = FALSE, ...)
 }
 \arguments{
 \item{x}{A fitted model.}

--- a/man/find_parameters.glmmTMB.Rd
+++ b/man/find_parameters.glmmTMB.Rd
@@ -2,26 +2,11 @@
 % Please edit documentation in R/find_parameters_mixed.R
 \name{find_parameters.glmmTMB}
 \alias{find_parameters.glmmTMB}
-\alias{find_parameters.nlmerMod}
 \alias{find_parameters.hglm}
 \alias{find_parameters.merMod}
 \title{Find names of model parameters from mixed models}
 \usage{
-\method{find_parameters}{glmmTMB}(
-  x,
-  effects = c("all", "fixed", "random"),
-  component = c("all", "conditional", "zi", "zero_inflated", "dispersion"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{nlmerMod}(
-  x,
-  effects = c("all", "fixed", "random"),
-  component = c("all", "conditional", "nonlinear"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{glmmTMB}(x, effects = "all", component = "all", flatten = FALSE, ...)
 
 \method{find_parameters}{hglm}(
   x,

--- a/man/find_parameters.zeroinfl.Rd
+++ b/man/find_parameters.zeroinfl.Rd
@@ -25,8 +25,8 @@ argument - but no auxiliary parameters). For \code{component = "distributional"}
 (or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{...}{Currently not used.}
 }

--- a/man/find_parameters.zeroinfl.Rd
+++ b/man/find_parameters.zeroinfl.Rd
@@ -23,13 +23,21 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
+\item{component}{Which type of parameters to return, such as parameters for the
 conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
+term, the instrumental variables or marginal effects be returned? Applies
+to models with zero-inflated and/or dispersion formula, or to models with
+instrumental variables (so called fixed-effects regressions), or models
+with marginal effects from \strong{mfx}. May be abbreviated. Note that the
 \emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+component, depending on the model. There are three convenient shortcuts:
+\code{component = "all"} returns all possible parameters.
+If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
+(everything that are fixed or random effects - depending on the \code{effects}
+argument - but no auxiliary parameters). For \code{component = "distributional"}
+(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
+\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}

--- a/man/find_parameters.zeroinfl.Rd
+++ b/man/find_parameters.zeroinfl.Rd
@@ -2,23 +2,9 @@
 % Please edit documentation in R/find_parameter_zi.R
 \name{find_parameters.zeroinfl}
 \alias{find_parameters.zeroinfl}
-\alias{find_parameters.mhurdle}
 \title{Find names of model parameters from zero-inflated models}
 \usage{
-\method{find_parameters}{zeroinfl}(
-  x,
-  component = c("all", "conditional", "zi", "zero_inflated"),
-  flatten = FALSE,
-  ...
-)
-
-\method{find_parameters}{mhurdle}(
-  x,
-  component = c("all", "conditional", "zi", "zero_inflated", "infrequent_purchase", "ip",
-    "auxiliary"),
-  flatten = FALSE,
-  ...
-)
+\method{find_parameters}{zeroinfl}(x, component = "all", flatten = FALSE, ...)
 }
 \arguments{
 \item{x}{A fitted model.}
@@ -51,6 +37,8 @@ elements:
 \item \code{conditional}, the "fixed effects" part from the model.
 \item \code{zero_inflated}, the "fixed effects" part from the zero-inflation
 component of the model.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{infrequent_purchase}, \code{ip}, and \code{auxiliary}.
 }
 }
 \description{

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -92,8 +92,16 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
-\item Special models are \code{mhurdle}, which also can have the components
-\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
+}
+
+\strong{Special models}
+
+Some model classes also allow rather uncommon options. These are:#'
+\itemize{
+\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
+\code{"ip"}, and \code{"auxiliary"}.
+\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
+\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
 }
 }
 

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -3,7 +3,6 @@
 \name{find_predictors}
 \alias{find_predictors}
 \alias{find_predictors.default}
-\alias{find_predictors.afex_aov}
 \title{Find names of model predictors}
 \usage{
 find_predictors(x, ...)
@@ -12,16 +11,6 @@ find_predictors(x, ...)
   x,
   effects = "fixed",
   component = "all",
-  flatten = FALSE,
-  verbose = TRUE,
-  ...
-)
-
-\method{find_predictors}{afex_aov}(
-  x,
-  effects = c("fixed", "random", "all"),
-  component = c("all", "conditional", "zi", "zero_inflated", "dispersion", "instruments",
-    "correlation", "smooth_terms"),
   flatten = FALSE,
   verbose = TRUE,
   ...

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -24,15 +24,15 @@ find_predictors(x, ...)
 \item{effects}{Should variables for fixed effects, random effects
 or both be returned? Only applies to mixed models. May be abbreviated.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{verbose}{Toggle warnings.}
 }
@@ -59,11 +59,10 @@ models that may contain smooth terms)
 }
 }
 \description{
-Returns the names of the predictor variables for the
-different parts of a model (like fixed or random effects, zero-inflated
-component, ...). Unlike \code{\link[=find_parameters]{find_parameters()}}, the names from
-\code{find_predictors()} match the original variable names from the data
-that was used to fit the model.
+Returns the names of the predictor variables for the different
+parts of a model (like fixed or random effects, zero-inflated component,
+...). Unlike \code{\link[=find_parameters]{find_parameters()}}, the names from \code{find_predictors()} match
+the original variable names from the data that was used to fit the model.
 }
 \section{Model components}{
 

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -24,13 +24,12 @@ find_predictors(x, ...)
 \item{effects}{Should variables for fixed effects, random effects
 or both be returned? Only applies to mixed models. May be abbreviated.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}
@@ -40,7 +39,7 @@ as character vector, not as list. Duplicated values are removed.}
 \value{
 A list of character vectors that represent the name(s) of the
 predictor variables. Depending on the combination of the arguments
-\code{effects} and \code{component}, the returned list has following elements:
+\code{effects} and \code{component}, the returned list can have following elements:
 \itemize{
 \item \code{conditional}, the "fixed effects" terms from the model
 \item \code{random}, the "random effects" terms from the model
@@ -53,6 +52,10 @@ component of the model
 the instrumental variables
 \item \code{correlation}, for models with correlation-component like \code{gls}, the
 variables used to describe the correlation structure
+\item \code{nonlinear}, for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), the staring estimates for the nonlinear parameters
+\item \code{smooth_terms} returns smooth terms, only applies to GAMs (or similar
+models that may contain smooth terms)
 }
 }
 \description{
@@ -89,6 +92,8 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
 }
 }
 

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -10,9 +10,8 @@ find_predictors(x, ...)
 
 \method{find_predictors}{default}(
   x,
-  effects = c("fixed", "random", "all"),
-  component = c("all", "conditional", "zi", "zero_inflated", "dispersion", "instruments",
-    "correlation", "smooth_terms"),
+  effects = "fixed",
+  component = "all",
   flatten = FALSE,
   verbose = TRUE,
   ...
@@ -91,6 +90,10 @@ models that may contain smooth terms).
 for models with zero-inflation or that can model the dispersion parameter.
 \item \code{"instruments"}: for instrumental-variable or some fixed effects regression,
 returns the instruments.
+\item \code{"nonlinear"}: for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), returns staring estimates for the nonlinear parameters.
+\item \code{"correlation"}: for models with correlation-component, like \code{gls}, the
+variables used to describe the correlation structure are returned.
 \item \code{"location"}: returns location parameters such as \code{conditional},
 \code{zero_inflated}, \code{smooth_terms}, or \code{instruments} (everything that are
 fixed or random effects - depending on the \code{effects} argument - but no

--- a/man/find_predictors.Rd
+++ b/man/find_predictors.Rd
@@ -95,12 +95,13 @@ auxiliary parameters).
 
 \strong{Special models}
 
-Some model classes also allow rather uncommon options. These are:#'
+Some model classes also allow rather uncommon options. These are:
 \itemize{
-\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
-\code{"ip"}, and \code{"auxiliary"}.
-\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
-\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
+\item \code{mhurdle}: \code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}
+\item \code{BGGM}: \code{"correlation"} and \code{"intercept"}
+\item \code{BFBayesFactor}, \code{glmx}: \code{"extra"}
+\item \code{averaging}:\code{"conditional"} and \code{"full"}
+\item \code{mjoint}: \code{"survival"}
 }
 }
 

--- a/man/find_random.Rd
+++ b/man/find_random.Rd
@@ -13,8 +13,8 @@ find_random(x, split_nested = FALSE, flatten = FALSE)
 effects will be returned as separated elements, not as single string
 with colon. See 'Examples'.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 }
 \value{
 A list of character vectors that represent the name(s) of the

--- a/man/find_smooth.Rd
+++ b/man/find_smooth.Rd
@@ -9,8 +9,8 @@ find_smooth(x, flatten = FALSE)
 \arguments{
 \item{x}{A (gam) model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 }
 \value{
 A character vector with the name(s) of the smooth terms.

--- a/man/find_terms.Rd
+++ b/man/find_terms.Rd
@@ -14,8 +14,8 @@ find_terms(x, ...)
 
 \item{...}{Currently not used.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{as_term_labels}{Logical, if \code{TRUE}, extracts model formula and tries to
 access the \code{"term.labels"} attribute. This should better mimic the \code{terms()}

--- a/man/find_variables.Rd
+++ b/man/find_variables.Rd
@@ -74,6 +74,10 @@ models that may contain smooth terms).
 for models with zero-inflation or that can model the dispersion parameter.
 \item \code{"instruments"}: for instrumental-variable or some fixed effects regression,
 returns the instruments.
+\item \code{"nonlinear"}: for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), returns staring estimates for the nonlinear parameters.
+\item \code{"correlation"}: for models with correlation-component, like \code{gls}, the
+variables used to describe the correlation structure are returned.
 \item \code{"location"}: returns location parameters such as \code{conditional},
 \code{zero_inflated}, \code{smooth_terms}, or \code{instruments} (everything that are
 fixed or random effects - depending on the \code{effects} argument - but no

--- a/man/find_variables.Rd
+++ b/man/find_variables.Rd
@@ -87,12 +87,13 @@ auxiliary parameters).
 
 \strong{Special models}
 
-Some model classes also allow rather uncommon options. These are:#'
+Some model classes also allow rather uncommon options. These are:
 \itemize{
-\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
-\code{"ip"}, and \code{"auxiliary"}.
-\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
-\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
+\item \code{mhurdle}: \code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}
+\item \code{BGGM}: \code{"correlation"} and \code{"intercept"}
+\item \code{BFBayesFactor}, \code{glmx}: \code{"extra"}
+\item \code{averaging}:\code{"conditional"} and \code{"full"}
+\item \code{mjoint}: \code{"survival"}
 }
 }
 

--- a/man/find_variables.Rd
+++ b/man/find_variables.Rd
@@ -18,15 +18,15 @@ find_variables(
 \item{effects}{Should variables for fixed effects, random effects
 or both be returned? Only applies to mixed models. May be abbreviated.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
-\item{flatten}{Logical, if \code{TRUE}, the values are returned
-as character vector, not as list. Duplicated values are removed.}
+\item{flatten}{Logical, if \code{TRUE}, the values are returned as character
+vector, not as list. Duplicated values are removed.}
 
 \item{verbose}{Toggle warnings.}
 }

--- a/man/find_variables.Rd
+++ b/man/find_variables.Rd
@@ -18,13 +18,12 @@ find_variables(
 \item{effects}{Should variables for fixed effects, random effects
 or both be returned? Only applies to mixed models. May be abbreviated.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{flatten}{Logical, if \code{TRUE}, the values are returned
 as character vector, not as list. Duplicated values are removed.}
@@ -84,6 +83,8 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
 }
 }
 

--- a/man/find_variables.Rd
+++ b/man/find_variables.Rd
@@ -83,8 +83,16 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
-\item Special models are \code{mhurdle}, which also can have the components
-\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
+}
+
+\strong{Special models}
+
+Some model classes also allow rather uncommon options. These are:#'
+\itemize{
+\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
+\code{"ip"}, and \code{"auxiliary"}.
+\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
+\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
 }
 }
 

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -109,6 +109,10 @@ models that may contain smooth terms).
 for models with zero-inflation or that can model the dispersion parameter.
 \item \code{"instruments"}: for instrumental-variable or some fixed effects regression,
 returns the instruments.
+\item \code{"nonlinear"}: for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), returns staring estimates for the nonlinear parameters.
+\item \code{"correlation"}: for models with correlation-component, like \code{gls}, the
+variables used to describe the correlation structure are returned.
 \item \code{"location"}: returns location parameters such as \code{conditional},
 \code{zero_inflated}, \code{smooth_terms}, or \code{instruments} (everything that are
 fixed or random effects - depending on the \code{effects} argument - but no

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -118,8 +118,16 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
-\item Special models are \code{mhurdle}, which also can have the components
-\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
+}
+
+\strong{Special models}
+
+Some model classes also allow rather uncommon options. These are:#'
+\itemize{
+\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
+\code{"ip"}, and \code{"auxiliary"}.
+\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
+\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
 }
 }
 

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -62,13 +62,12 @@ that have no missing data in the variables used for model fitting.}
 effects (\code{"random"}) or both (\code{"all"}) be returned? Only applies to mixed
 or gee models.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{shape}{Return long or wide data? Only applicable in repeated measures
 designs.}
@@ -119,6 +118,8 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
 }
 }
 

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -122,12 +122,13 @@ auxiliary parameters).
 
 \strong{Special models}
 
-Some model classes also allow rather uncommon options. These are:#'
+Some model classes also allow rather uncommon options. These are:
 \itemize{
-\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
-\code{"ip"}, and \code{"auxiliary"}.
-\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
-\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
+\item \code{mhurdle}: \code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}
+\item \code{BGGM}: \code{"correlation"} and \code{"intercept"}
+\item \code{BFBayesFactor}, \code{glmx}: \code{"extra"}
+\item \code{averaging}:\code{"conditional"} and \code{"full"}
+\item \code{mjoint}: \code{"survival"}
 }
 }
 

--- a/man/get_data.Rd
+++ b/man/get_data.Rd
@@ -62,12 +62,12 @@ that have no missing data in the variables used for model fitting.}
 effects (\code{"random"}) or both (\code{"all"}) be returned? Only applies to mixed
 or gee models.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{shape}{Return long or wide data? Only applicable in repeated measures
 designs.}

--- a/man/get_parameters.BGGM.Rd
+++ b/man/get_parameters.BGGM.Rd
@@ -103,13 +103,21 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
+\item{component}{Which type of parameters to return, such as parameters for the
 conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
+term, the instrumental variables or marginal effects be returned? Applies
+to models with zero-inflated and/or dispersion formula, or to models with
+instrumental variables (so called fixed-effects regressions), or models
+with marginal effects from \strong{mfx}. May be abbreviated. Note that the
 \emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+component, depending on the model. There are three convenient shortcuts:
+\code{component = "all"} returns all possible parameters.
+If \code{component = "location"}, location parameters such as \code{conditional},
+\code{zero_inflated}, \code{smooth_terms}, or \code{instruments} are returned
+(everything that are fixed or random effects - depending on the \code{effects}
+argument - but no auxiliary parameters). For \code{component = "distributional"}
+(or \code{"auxiliary"}), components like \code{sigma}, \code{dispersion},
+\code{beta} or \code{precision} (and other auxiliary parameters) are returned.}
 
 \item{summary}{Logical, indicates whether the full posterior samples
 (\code{summary = FALSE})) or the summarized centrality indices of

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -79,12 +79,13 @@ auxiliary parameters).
 
 \strong{Special models}
 
-Some model classes also allow rather uncommon options. These are:#'
+Some model classes also allow rather uncommon options. These are:
 \itemize{
-\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
-\code{"ip"}, and \code{"auxiliary"}.
-\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
-\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
+\item \code{mhurdle}: \code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}
+\item \code{BGGM}: \code{"correlation"} and \code{"intercept"}
+\item \code{BFBayesFactor}, \code{glmx}: \code{"extra"}
+\item \code{averaging}:\code{"conditional"} and \code{"full"}
+\item \code{mjoint}: \code{"survival"}
 }
 }
 

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -65,6 +65,10 @@ models that may contain smooth terms).
 for models with zero-inflation or that can model the dispersion parameter.
 \item \code{"instruments"}: for instrumental-variable or some fixed effects regression,
 returns the instruments.
+\item \code{"nonlinear"}: for non-linear models (like models of class \code{nlmerMod} or
+\code{nls}), returns staring estimates for the nonlinear parameters.
+\item \code{"correlation"}: for models with correlation-component, like \code{gls}, the
+variables used to describe the correlation structure are returned.
 \item \code{"location"}: returns location parameters such as \code{conditional},
 \code{zero_inflated}, \code{smooth_terms}, or \code{instruments} (everything that are
 fixed or random effects - depending on the \code{effects} argument - but no

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -75,8 +75,16 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
-\item Special models are \code{mhurdle}, which also can have the components
-\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
+}
+
+\strong{Special models}
+
+Some model classes also allow rather uncommon options. These are:#'
+\itemize{
+\item \code{mhurdle}, which also can have the components \code{"infrequent_purchase"},
+\code{"ip"}, and \code{"auxiliary"}.
+\item \code{BGGM}, which also allows options \code{"correlation"} and \code{"intercept"}.
+\item \code{BGBFBayesFactorGM}, which also allows the option \code{"extra"}.
 }
 }
 

--- a/man/get_parameters.Rd
+++ b/man/get_parameters.Rd
@@ -75,6 +75,8 @@ fixed or random effects - depending on the \code{effects} argument - but no
 auxiliary parameters).
 \item \code{"distributional"} (or \code{"auxiliary"}): components like \code{sigma}, \code{dispersion},
 \code{beta} or \code{precision} (and other auxiliary parameters) are returned.
+\item Special models are \code{mhurdle}, which also can have the components
+\code{"infrequent_purchase"}, \code{"ip"}, and \code{"auxiliary"}.
 }
 }
 

--- a/man/get_parameters.betamfx.Rd
+++ b/man/get_parameters.betamfx.Rd
@@ -16,13 +16,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.betamfx.Rd
+++ b/man/get_parameters.betamfx.Rd
@@ -16,12 +16,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.betareg.Rd
+++ b/man/get_parameters.betareg.Rd
@@ -48,13 +48,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.betareg.Rd
+++ b/man/get_parameters.betareg.Rd
@@ -48,12 +48,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.gamm.Rd
+++ b/man/get_parameters.gamm.Rd
@@ -23,13 +23,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.gamm.Rd
+++ b/man/get_parameters.gamm.Rd
@@ -23,12 +23,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.zeroinfl.Rd
+++ b/man/get_parameters.zeroinfl.Rd
@@ -28,13 +28,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Should all predictor variables, predictor variables for the
-conditional model, the zero-inflated part of the model, the dispersion
-term or the instrumental variables be returned? Applies to models
-with zero-inflated and/or dispersion formula, or to models with instrumental
-variable (so called fixed-effects regressions). May be abbreviated. Note that the
-\emph{conditional} component is also called \emph{count} or \emph{mean}
-component, depending on the model.}
+\item{component}{Indicates which model component shoild be returned. E.g.,
+should all predictor variables, predictor variables for the conditional
+model, the zero-inflated part of the model, the dispersion term or the
+instrumental variables be returned? See section \emph{Model Components} for futher
+details. May be abbreviated. Note that the \emph{conditional} component is also
+called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }

--- a/man/get_parameters.zeroinfl.Rd
+++ b/man/get_parameters.zeroinfl.Rd
@@ -28,12 +28,12 @@
 \arguments{
 \item{x}{A fitted model.}
 
-\item{component}{Indicates which model component shoild be returned. E.g.,
+\item{component}{Indicates which model component should be returned. E.g.,
 should all predictor variables, predictor variables for the conditional
 model, the zero-inflated part of the model, the dispersion term or the
-instrumental variables be returned? See section \emph{Model Components} for futher
-details. May be abbreviated. Note that the \emph{conditional} component is also
-called \emph{count} or \emph{mean} component, depending on the model.}
+instrumental variables be returned? See section \emph{Model Components} for
+further details. May be abbreviated. Note that the \emph{conditional} component is
+also called \emph{count} or \emph{mean} component, depending on the model.}
 
 \item{...}{Currently not used.}
 }


### PR DESCRIPTION
Don't show "usage" for all classes (make docs clearer)