### PR TITLE
`get_datagrid()` gives a more informative error message when a variable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.0.1.3
+Version: 1.0.1.4
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # insight 1.02
 
+## Changes
+
+* `get_datagrid()` gives a more informative error message when a variable
+  specified in `by` was not found in the data.
+
 ## Bug fixes
 
 * Option `"terciles"` and `"terciles2"` in `get_datagrid()` were swapped, i.e.

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -262,6 +262,12 @@ get_datagrid.data.frame <- function(x,
     specs$varname <- as.character(specs$varname) # make sure it's a string not fac
     specs <- specs[!duplicated(specs$varname), ] # Drop duplicates
 
+    # sanity check - target in data?
+    if (!all(specs$varname %in% colnames(x))) {
+      format_error(paste0(
+        "Variable `", setdiff(specs$varname, colnames(x))[1], "` was not found in the data. Please check the spelling." # nolint
+      ))
+    }
     specs$is_factor <- vapply(x[specs$varname], function(x) is.factor(x) || is.character(x), TRUE)
 
     # Create target list of factors -----------------------------------------

--- a/tests/testthat/test-get_datagrid.R
+++ b/tests/testthat/test-get_datagrid.R
@@ -450,3 +450,13 @@ test_that("get_datagrid - include_random works with interacting random effects",
     tolerance = 1e-3
   )
 })
+
+
+test_that("get_datagrid - informative error when by not found", {
+  data(iris)
+  m <- lm(Sepal.Length ~ Species + Petal.Length, data = iris)
+  expect_error(
+    insight::get_datagrid(m, by = list(Sepal.Something = c(10, 40, 50))),
+    regex = "was not found"
+  )
+})


### PR DESCRIPTION
specified in `by` was not found in the data.