### PR TITLE
get_varcov() fails when brms models have monotonic effects

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.0.1.6
+Version: 1.0.1.7
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,9 @@
 * `include_random` in `get_datagrid()` now works for nested random effects, i.e.
   for more than one group level factor in the random effects.
 
+* Fixed issue in `get_varcov()` for models of class `brmsfit` that included
+  monotonic effects.
+
 # insight 1.01
 
 ## General

--- a/R/get_varcov.R
+++ b/R/get_varcov.R
@@ -604,7 +604,15 @@ get_varcov.brmsfit <- function(x, component = "conditional", verbose = TRUE, ...
   params <- find_parameters(x, effects = "fixed", component = component, flatten = TRUE)
   params <- gsub("^b_", "", params)
 
-  vc <- .safe_vcov(x)[params, params, drop = FALSE]
+  # get full varcov
+  vc <- .safe_vcov(x)
+
+  # check if we can filter - for models with monotonic effects, we have
+  # different parameter names, this filtering will fail here
+  if (all(params %in% colnames(vc))) {
+    vc <- vc[params, params, drop = FALSE]
+  }
+
   .process_vcov(vc, verbose, ...)
 }
 


### PR DESCRIPTION
Fixes #998