### PR TITLE
`get_datagrid()` should include a dummy-weight variable for glmmTMB models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.0.2
+Version: 1.0.2.1
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
-# insight 1.02
+# insight (devel)
+
+## Changes
+
+* `get_datagrid()` now includes a dummy column for model weights (values `NA`),
+  to work with models that used weights.
+
+# insight 1.0.2
 
 ## Changes
 
@@ -20,7 +27,7 @@
 * Fixed issue in `get_varcov()` for models of class `brmsfit` that included
   monotonic effects.
 
-# insight 1.01
+# insight 1.0.1
 
 ## General
 

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -585,9 +585,9 @@ get_datagrid.default <- function(x,
   if (!inherits(x, "brmsfit") && !is.null(w)) {
     # for lme, can't be NA
     if (inherits(x, c("lme", "gls"))) {
-      vm[[w]] <- 1
+      vm[w] <- 1
     } else {
-      vm[[w]] <- NA_real_
+      vm[w] <- NA_real_
     }
   }
 

--- a/R/get_datagrid.R
+++ b/R/get_datagrid.R
@@ -580,6 +580,17 @@ get_datagrid.default <- function(x,
     }
   }
 
+  # if model has weights, we need to add a dummy for certain classes, e.g. glmmTMB
+  w <- insight::find_weights(x)
+  if (!inherits(x, "brmsfit") && !is.null(w)) {
+    # for lme, can't be NA
+    if (inherits(x, c("lme", "gls"))) {
+      vm[[w]] <- 1
+    } else {
+      vm[[w]] <- NA_real_
+    }
+  }
+
   if (isFALSE(include_smooth)) {
     vm[colnames(vm) %in% clean_names(find_smooth(x, flatten = TRUE))] <- NULL
   }

--- a/tests/testthat/test-get_datagrid.R
+++ b/tests/testthat/test-get_datagrid.R
@@ -487,3 +487,21 @@ test_that("get_datagrid - informative error when by not found", {
     regex = "was not found"
   )
 })
+
+
+test_that("get_datagrid - include weights", {
+  skip_if_not_installed("glmmTMB")
+  skip_if_not_installed("lme4")
+
+  data(sleepstudy, package = "lme4")
+  set.seed(123)
+  sleepstudy$wei_factor <- abs(rnorm(nrow(sleepstudy), 1, 0.4))
+
+  m <- glmmTMB::glmmTMB(Reaction ~ Days + (1 | Subject), data = sleepstudy, weights = wei_factor)
+  d <- insight::get_datagrid(m, "Days")
+  expect_named(d, c("Days", "Subject", "wei_factor"))
+
+  m <- glmmTMB::glmmTMB(Reaction ~ Days + (1 | Subject), data = sleepstudy)
+  d <- insight::get_datagrid(m, "Days")
+  expect_named(d, c("Days", "Subject"))
+})


### PR DESCRIPTION
Fixes #1002
Fixes #1001 