### PR TITLE
Fix get_predicted for multivariate (i.e., multiple outcomes) models

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.1.0.19
+Version: 1.1.0.21
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
   was used to fit the model (model frame), which can lead to different results
   when the original data contained missing values.
 
+* Fixed issue for `get_predicted()` with multivariate response models.
+
 # insight 1.1.0
 
 ## Breaking Changes

--- a/R/get_predicted_args.R
+++ b/R/get_predicted_args.R
@@ -52,6 +52,12 @@
   # Get info
   info <- model_info(x, verbose = FALSE)
 
+  # just keep information of one model, if multivate. the "is_linear" is just
+  # to check that we indeed have multiple info-lists
+  if (is_multivariate(x) && is.null(info$is_linear)) {
+    info <- info[[1]]
+  }
+
   # Data
   if (!is.null(dots$newdata) && is.null(data)) data <- dots$newdata
   if (is.null(data)) data <- get_data(x, verbose = FALSE)


### PR DESCRIPTION
Fixes #1034