### PR TITLE
Allow dpars-argument to be passed to predict-function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.1.0.37
+Version: 1.1.0.38
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/R/get_predicted_args.R
+++ b/R/get_predicted_args.R
@@ -105,8 +105,17 @@
     predict <- "prediction"
   }
 
+  # intermediate step, evaluate dpars                             ------------
+  ############################################################################
+
   # brms-exceptions: predict distributional parameters
-  if (predict %in% c(find_auxiliary(x, verbose = FALSE), "mu")) {
+  if (!is.null(dots$dpars)) {
+    # if user provided dpars argument, we just pass it to the predict-function.
+    # we don't overwrite the "predict" argument, because this allows us to pass
+    # dpars to "posterior_predict()" - else, when dpars are provided via the
+    # predict-argument, we always set predict = "expectation"
+    dpar <- dots$dpars
+  } else if (inherits(x, "brmsfit") && predict %in% c(find_auxiliary(x, verbose = FALSE), "mu")) {
     dpar <- predict
     predict <- "expectation"
   }

--- a/R/get_predicted_bayesian.R
+++ b/R/get_predicted_bayesian.R
@@ -74,7 +74,9 @@ get_predicted.stanreg <- function(x,
 
   # Fix dots content
   dots <- list(...)
-  dots[["newdata"]] <- NULL
+  # these arguments have already been set
+  dots[names(fun_args)] <- NULL
+
   fun_args <- c(fun_args, dots)
 
   model_family <- get_family(x)


### PR DESCRIPTION
if user provided `dpars` argument, we just pass it to the `predict()`-function. we don't overwrite the `predict` argument, because this allows us to pass dpars to `posterior_predict()` - else, when dpars are provided via the `predict`-argument, we always set `predict = "expectation"`, thus, have no option to use dpars with `posterior_predictions()`.
