### PR TITLE
format_bf() doesn't accepta digits arguments

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.5.0
+Version: 1.5.0.1
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.5.0.1
+Version: 1.5.0.2
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# insight (devel)
+
+## Changes
+
+* `format_bf()` gains a digits argument.
+
 # insight 1.5.0
 
 ## Changes

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -67,10 +67,9 @@ format_bf <- function(
   )
 
   # what is extreme small?
-  if (digits < 3) {
+  extreme_small <- (10^max(digits))
+  if (extreme_small < 1000) {
     extreme_small <- 1000
-  } else {
-    extreme_small <- (10^digits)
   }
 
   ## Very big/small values

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -66,8 +66,15 @@ format_bf <- function(
     format_value(bf, digits = digits)
   )
 
+  # what is extreme small?
+  if (digits < 3) {
+    extreme_small <- 1000
+  } else {
+    extreme_small <- (10^digits)
+  }
+
   ## Very big/small values
-  is_extreme <- bf_orig > 1000 | bf_orig < 1 / (10^digits)
+  is_extreme <- bf_orig > 1000 | bf_orig < 1 / extreme_small
   if (any(is_extreme)) {
     if (exact) {
       bf_text[is_extreme] <- ifelse(
@@ -76,7 +83,7 @@ format_bf <- function(
         bf_text[is_extreme]
       )
       bf_text[is_extreme] <- ifelse(
-        bf_orig[is_extreme] < 1 / (10^digits),
+        bf_orig[is_extreme] < 1 / extreme_small,
         ifelse(
           is_small[is_extreme],
           sprintf("= 1/%.2e", bf[is_extreme]),
@@ -91,7 +98,7 @@ format_bf <- function(
         bf_text[is_extreme]
       )
       bf_text[is_extreme] <- ifelse(
-        bf_orig[is_extreme] < 1 / (10^digits),
+        bf_orig[is_extreme] < 1 / extreme_small,
         ifelse(is_small[is_extreme], "< 1/1000", "< 0.001"), # nolint
         bf_text[is_extreme]
       )

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -35,8 +35,9 @@ format_bf <- function(
   exact = FALSE,
   digits = NULL
 ) {
+  bad_bf <- is.na(bf)
   if (is.na(na_reference)) {
-    bf[bad_bf <- is.na(bf)] <- 1
+    bf[bad_bf] <- 1
   } else {
     bf[is.na(bf)] <- na_reference
   }
@@ -98,7 +99,14 @@ format_bf <- function(
       )
       bf_text[is_extreme] <- ifelse(
         bf_orig[is_extreme] < 1 / extreme_small,
-        ifelse(is_small[is_extreme], "< 1/1000", "< 0.001"), # nolint
+        ifelse(
+          is_small[is_extreme],
+          paste0("< 1/", extreme_small),
+          paste0(
+            "< ",
+            format_value(1 / extreme_small, digits = round(log10(extreme_small)))
+          )
+        ),
         bf_text[is_extreme]
       )
     }
@@ -110,8 +118,8 @@ format_bf <- function(
     paste0(bf_text, "***"),
     ifelse(
       bf_orig > 10,
-      paste0(bf_text, "**"), # nolint
-      ifelse(bf_orig > 3, paste0(bf_text, "*"), bf_text) # nolint
+      paste0(bf_text, "**"),
+      ifelse(bf_orig > 3, paste0(bf_text, "*"), bf_text)
     )
   )
 
@@ -119,11 +127,11 @@ format_bf <- function(
   if (!is.null(inferiority_star)) {
     bf_text <- ifelse(
       bf_orig < (1 / 30),
-      paste0(bf_text, paste(rep_len(inferiority_star, 3), collapse = "")), # nolint
+      paste0(bf_text, paste(rep_len(inferiority_star, 3), collapse = "")),
       ifelse(
         bf_orig < 0.1,
-        paste0(bf_text, paste(rep_len(inferiority_star, 2), collapse = "")), # nolint
-        ifelse(bf_orig < (1 / 3), paste0(bf_text, inferiority_star), bf_text) # nolint
+        paste0(bf_text, paste(rep_len(inferiority_star, 2), collapse = "")),
+        ifelse(bf_orig < (1 / 3), paste0(bf_text, inferiority_star), bf_text)
       )
     )
   }

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -76,9 +76,9 @@ format_bf <- function(
         bf_text[is_extreme]
       )
       bf_text[is_extreme] <- ifelse(
-        bf_orig[is_extreme] < 1 / 1000,
+        bf_orig[is_extreme] < 1 / (10^digits),
         ifelse(
-          is_small[is_extreme], # nolint
+          is_small[is_extreme],
           sprintf("= 1/%.2e", bf[is_extreme]),
           sprintf("= %.2e", bf_orig[is_extreme])
         ),
@@ -91,7 +91,7 @@ format_bf <- function(
         bf_text[is_extreme]
       )
       bf_text[is_extreme] <- ifelse(
-        bf_orig[is_extreme] < 1 / 1000,
+        bf_orig[is_extreme] < 1 / (10^digits),
         ifelse(is_small[is_extreme], "< 1/1000", "< 0.001"), # nolint
         bf_text[is_extreme]
       )

--- a/R/format_bf.R
+++ b/R/format_bf.R
@@ -9,6 +9,8 @@
 #' @param inferiority_star String, indicating the symbol that is used to
 #'   indicate inferiority, i.e. when the Bayes Factor is smaller than one third
 #'   (the thresholds are smaller than one third, 1/10 and 1/30).
+#' @param digits Number of significant digits. Can also be `"scientific"` (which
+#' is identical to `exact = TRUE`).
 #' @inheritParams format_p
 #'
 #' @return A formatted string.
@@ -30,7 +32,8 @@ format_bf <- function(
   name = "BF",
   protect_ratio = FALSE,
   na_reference = NA,
-  exact = FALSE
+  exact = FALSE,
+  digits = NULL
 ) {
   if (is.na(na_reference)) {
     bf[bad_bf <- is.na(bf)] <- 1
@@ -47,7 +50,15 @@ format_bf <- function(
     is_small <- logical(length(bf))
   }
 
-  digits <- ifelse(is.na(bf), 0, ifelse(bf < 1, 3, 2)) # nolint
+  # digis = scientific is the same as exact = TRUE
+  if (identical(digits, "scientific")) {
+    exact <- TRUE
+    digits <- NULL
+  }
+
+  if (is.null(digits) || is.character(digits)) {
+    digits <- ifelse(is.na(bf), 0, ifelse(bf < 1, 3, 2))
+  }
 
   bf_text <- paste0(
     "= ",
@@ -56,7 +67,7 @@ format_bf <- function(
   )
 
   ## Very big/small values
-  is_extreme <- bf_orig > 1000 | bf_orig < 1 / 1000
+  is_extreme <- bf_orig > 1000 | bf_orig < 1 / (10^digits)
   if (any(is_extreme)) {
     if (exact) {
       bf_text[is_extreme] <- ifelse(

--- a/man/format_bf.Rd
+++ b/man/format_bf.Rd
@@ -12,7 +12,8 @@ format_bf(
   name = "BF",
   protect_ratio = FALSE,
   na_reference = NA,
-  exact = FALSE
+  exact = FALSE,
+  digits = NULL
 )
 }
 \arguments{
@@ -36,6 +37,9 @@ indicate inferiority, i.e. when the Bayes Factor is smaller than one third
 \item{exact}{Should very large or very small values be reported with a
 scientific format (e.g., 4.24e5), or as truncated values (as "> 1000" and
 "< 1/1000").}
+
+\item{digits}{Number of significant digits. Can also be \code{"scientific"} (which
+is identical to \code{exact = TRUE}).}
 }
 \value{
 A formatted string.

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -209,6 +209,22 @@ test_that("format others", {
   expect_type(insight::format_pd(0.02), "character")
   expect_identical(nchar(format_bf(4)), 9L)
   expect_identical(
+    format_bf(c(0.000045, 0.233, NA, 1557, 3.54), digits = 8),
+    c("BF = 0.00004500", "BF = 0.23300000", "", "BF > 1000", "BF = 3.54000000")
+  )
+  expect_identical(
+    format_bf(c(0.000045, 0.233, NA, 1557, 3.54)),
+    c("BF < 0.001", "BF = 0.233", "", "BF > 1000", "BF = 3.54")
+  )
+  expect_identical(
+    format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 4),
+    c("BF = 4.50e-05", "BF = 0.2330", "", "BF = 1.56e+03", "BF = 3.5400")
+  )
+  expect_identical(
+    format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 2),
+    c("BF = 4.50e-05", "BF = 0.23", "", "BF = 1.56e+03", "BF = 3.54")
+  )
+  expect_identical(
     format_bf(c(0.000045, 0.033, NA, 1557, 3.54)),
     c("BF < 0.001", "BF = 0.033", "", "BF > 1000", "BF = 3.54")
   )

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -225,6 +225,10 @@ test_that("format others", {
     c("BF = 4.50e-05", "BF = 0.23", "", "BF = 1.56e+03", "BF = 3.54")
   )
   expect_identical(
+    format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 10),
+    c("BF = 0.0000450000", "BF = 0.2330000000", "", "BF = 1.56e+03", "BF = 3.5400000000")
+  )
+  expect_identical(
     format_bf(c(0.000045, 0.033, NA, 1557, 3.54)),
     c("BF < 0.001", "BF = 0.033", "", "BF > 1000", "BF = 3.54")
   )

--- a/tests/testthat/test-format.R
+++ b/tests/testthat/test-format.R
@@ -208,6 +208,18 @@ test_that("format_ci, character", {
 test_that("format others", {
   expect_type(insight::format_pd(0.02), "character")
   expect_identical(nchar(format_bf(4)), 9L)
+  expect_identical(format_bf(0.000000045), "BF < 0.001")
+  expect_identical(format_bf(0.000000045, exact = TRUE), "BF = 4.50e-08")
+  expect_identical(format_bf(0.000000045, digits = 3), "BF < 0.001")
+  expect_identical(
+    format_bf(0.000000045, digits = 3, protect_ratio = TRUE),
+    "BF < 1/1000"
+  )
+  expect_identical(format_bf(0.000000045, digits = 10), "BF = 0.0000000450")
+  expect_identical(
+    format_bf(0.000000045, digits = 10, protect_ratio = TRUE),
+    "BF = 1/2.2222222222e+07"
+  )
   expect_identical(
     format_bf(c(0.000045, 0.233, NA, 1557, 3.54), digits = 8),
     c("BF = 0.00004500", "BF = 0.23300000", "", "BF > 1000", "BF = 3.54000000")


### PR DESCRIPTION
Fixes #1181

Examples:

@DominiqueMakowski Are you ok with the combination of `exact` and `digits`?

``` r
library(insight)
format_bf(c(0.000045, 0.233, NA, 1557, 3.54))
#> [1] "BF < 0.001" "BF = 0.233" ""           "BF > 1000"  "BF = 3.54"
format_bf(c(0.000045, 0.233, NA, 1557, 3.54), digits = 8)
#> [1] "BF = 0.00004500" "BF = 0.23300000" ""                "BF > 1000"      
#> [5] "BF = 3.54000000"
format_bf(c(0.000045, 0.233, NA, 1557, 3.54), digits = 10)
#> [1] "BF = 0.0000450000" "BF = 0.2330000000" ""                 
#> [4] "BF > 1000"         "BF = 3.5400000000"
format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 2)
#> [1] "BF = 4.50e-05" "BF = 0.23"     ""              "BF = 1.56e+03"
#> [5] "BF = 3.54"
format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 4)
#> [1] "BF = 4.50e-05" "BF = 0.2330"   ""              "BF = 1.56e+03"
#> [5] "BF = 3.5400"
format_bf(c(0.000045, 0.233, NA, 1557, 3.54), exact = TRUE, digits = 10)
#> [1] "BF = 0.0000450000" "BF = 0.2330000000" ""                 
#> [4] "BF = 1.56e+03"     "BF = 3.5400000000"
```

<sup>Created on 2026-04-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
