### PR TITLE
Fix `null_model()` for inline offsets with nested parens and trailing terms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # insight (devel)
 
+## Bug fixes
+
+* `null_model()` no longer fails for models whose offset is written inline in
+  the formula with a nested-parenthesis expression followed by further terms
+  (e.g. `y ~ x + offset(log(exposure)) + factor(year)`). The offset term is now
+  extracted from the formula's language tree instead of by a paren-blind regex.
+
 ## Changes
 
 * `format_ci()` gains a `separator` argument, to customize the separator for

--- a/R/null_model.R
+++ b/R/null_model.R
@@ -315,21 +315,43 @@ null_model.glmmadmb <- null_model.glmmTMB
       # its argument. A regex on the deparsed formula cannot reliably extract
       # the offset expression when that expression contains nested parentheses
       # (e.g. `offset(log(x))`) or when further terms follow the offset in the
-      # formula (e.g. `... + offset(log(x)) + factor(year)`): the closing paren
-      # of `offset(` is then no longer the last `)` in the string, so the old
-      # regex captured an unbalanced, unparseable substring.
-      offset_expr <- NULL
-      find_offset_call <- function(e) {
-        if (!is.null(offset_expr) || !is.call(e)) {
+      # formula (e.g. `... + offset(log(x)) + factor(year)`): the closing paren of
+      # `offset(` is then no longer the last `)` in the string, so the old regex
+      # captured an unbalanced, unparseable substring.
+      .find_offset_call <- function(e) {
+        # If the current element is not a call (e.g., a symbol or a constant),
+        # it cannot be an offset() call, so we return NULL.
+        if (!is.call(e)) {
           return(NULL)
         }
+
+        # Check if the current call is `offset(...)`
+        # We ensure it's exactly the function 'offset' and has at least one argument.
         if (identical(e[[1L]], as.name("offset")) && length(e) >= 2L) {
-          offset_expr <<- e[[2L]]
-          return(NULL)
+          # Return the argument passed to offset()
+          return(e[[2L]])
         }
-        for (i in seq_along(e)) find_offset_call(e[[i]])
+
+        # Recursively walking the syntax tree. If it's not the offset call,
+        # recursively check all components of the current call. We iterate over
+        # all elements (e.g., in `y ~ x + offset(z)`, `e` is a call to `~` with
+        # arguments `y` and `x + offset(z)`)
+        for (i in seq_along(e)) {
+          res <- .find_offset_call(e[[i]])
+          # If a non-NULL result is found in any of the child nodes, immediately
+          # return it up the call stack.
+          if (!is.null(res)) {
+            return(res)
+          }
+        }
+
+        # If the offset call is not found in this branch, return NULL
+        return(NULL)
       }
-      find_offset_call(f)
+      # Executing the search and formatting the result. Start the recursive
+      # search on the formula 'f'
+      offset_expr <- .find_offset_call(f)
+
       if (is.null(offset_expr)) {
         NULL
       } else {

--- a/R/null_model.R
+++ b/R/null_model.R
@@ -307,13 +307,34 @@ null_model.glmmadmb <- null_model.glmmTMB
 .grep_offset_term <- function(model_formula) {
   tryCatch(
     {
-      f <- safe_deparse(model_formula$conditional)
-      if (grepl("offset(", f, fixed = TRUE)) {
-        out <- gsub("(.*)offset\\((.*)\\)(.*)", "\\2", f)
-      } else {
-        out <- NULL
+      f <- model_formula$conditional
+      if (is.null(f)) {
+        return(NULL)
       }
-      out
+      # Walk the formula's language tree to find the offset() call and return
+      # its argument. A regex on the deparsed formula cannot reliably extract
+      # the offset expression when that expression contains nested parentheses
+      # (e.g. `offset(log(x))`) or when further terms follow the offset in the
+      # formula (e.g. `... + offset(log(x)) + factor(year)`): the closing paren
+      # of `offset(` is then no longer the last `)` in the string, so the old
+      # regex captured an unbalanced, unparseable substring.
+      offset_expr <- NULL
+      find_offset_call <- function(e) {
+        if (!is.null(offset_expr) || !is.call(e)) {
+          return(NULL)
+        }
+        if (identical(e[[1L]], as.name("offset")) && length(e) >= 2L) {
+          offset_expr <<- e[[2L]]
+          return(NULL)
+        }
+        for (i in seq_along(e)) find_offset_call(e[[i]])
+      }
+      find_offset_call(f)
+      if (is.null(offset_expr)) {
+        NULL
+      } else {
+        safe_deparse(offset_expr)
+      }
     },
     error = function(e) {
       NULL

--- a/tests/testthat/test-null_model.R
+++ b/tests/testthat/test-null_model.R
@@ -156,6 +156,34 @@ test_that("null_model with offset", {
 })
 
 
+test_that("null_model with nested-parenthesis offset and trailing terms", {
+  # `.grep_offset_term()` used to extract the offset with a paren-blind regex,
+  # which broke when the offset expression itself contained parentheses
+  # (`offset(log(x))`) AND further terms followed the offset in the formula
+  # (`... + offset(log(x)) + g`): the offset's closing paren was then no longer
+  # the last `)` in the deparsed formula, so an unbalanced, unparseable string
+  # was captured and null_model() errored.
+  set.seed(123)
+  N <- 200
+  x <- runif(N, 0, 10)
+  g <- factor(sample(letters[1:3], N, replace = TRUE))
+  off <- rgamma(N, 3, 2)
+  y <- rpois(N, exp(-1 + 0.5 * x + log(off)))
+  d <<- data.frame(y = y, x = x, g = g, off = off)
+
+  # inline offset (nested paren) with a factor term AFTER it
+  m1 <- glm(y ~ x + offset(log(off)) + g, data = d, family = "poisson")
+  # equivalent model with the offset supplied via the `offset` argument
+  m2 <- glm(y ~ x + g, offset = log(off), data = d, family = "poisson")
+
+  nm1 <- null_model(m1)
+  nm2 <- null_model(m2)
+  # the null model builds without error and keeps the offset
+  expect_identical(find_offset(nm1), "off")
+  expect_equal(coef(nm1), coef(nm2), tolerance = 1e-4)
+})
+
+
 skip_if_not_installed("MASS")
 skip_if_not_installed("withr")
 withr::with_options(

--- a/tests/testthat/test-null_model.R
+++ b/tests/testthat/test-null_model.R
@@ -189,6 +189,28 @@ test_that("null_model with nested-parenthesis offset and trailing terms", {
 })
 
 
+test_that("null_model with nested-parenthesis offset, glmmTMB", {
+  # same shape as the test above, but for glmmTMB - the class the issue was
+  # originally reported for. The conditional formula deparses to
+  # `mpg ~ disp + offset(log(wt)) + factor(gear)`, so the offset's closing
+  # paren is not the last `)` in the string.
+  data(mtcars)
+  m1 <- suppressWarnings(glmmTMB::glmmTMB(
+    mpg ~ disp + offset(log(wt)) + factor(gear) + (1 | cyl),
+    data = mtcars
+  ))
+  m2 <- suppressWarnings(glmmTMB::glmmTMB(
+    mpg ~ disp + factor(gear) + (1 | cyl),
+    offset = log(wt),
+    data = mtcars
+  ))
+  nm1 <- null_model(m1)
+  nm2 <- null_model(m2)
+  expect_identical(find_offset(nm1), "wt")
+  expect_equal(glmmTMB::fixef(nm1), glmmTMB::fixef(nm2), tolerance = 1e-4)
+})
+
+
 skip_if_not_installed("MASS")
 skip_if_not_installed("withr")
 withr::with_options(

--- a/tests/testthat/test-null_model.R
+++ b/tests/testthat/test-null_model.R
@@ -162,10 +162,12 @@ test_that("null_model with offset-3", {
 test_that("null_model with nested-parenthesis offset and trailing terms", {
   # `.grep_offset_term()` used to extract the offset with a paren-blind regex,
   # which broke when the offset expression itself contained parentheses
-  # (`offset(log(x))`) AND further terms followed the offset in the formula
-  # (`... + offset(log(x)) + g`): the offset's closing paren was then no longer
-  # the last `)` in the deparsed formula, so an unbalanced, unparseable string
-  # was captured and null_model() errored.
+  # (`offset(log(x))`) AND a term that *itself* contains parentheses followed
+  # the offset in the formula (`... + offset(log(x)) + factor(g)`): the offset's
+  # closing paren was then no longer the last `)` in the deparsed formula, so an
+  # unbalanced, unparseable string was captured and null_model() errored.
+  # NOTE: the trailing term must contain parens, otherwise the offset's `)` is
+  # still the last one in the string and the old regex happened to work.
   set.seed(123)
   N <- 200
   x <- runif(N, 0, 10)
@@ -174,10 +176,10 @@ test_that("null_model with nested-parenthesis offset and trailing terms", {
   y <- rpois(N, exp(-1 + 0.5 * x + log(off)))
   d <<- data.frame(y = y, x = x, g = g, off = off)
 
-  # inline offset (nested paren) with a factor term AFTER it
-  m1 <- glm(y ~ x + offset(log(off)) + g, data = d, family = "poisson")
+  # inline offset (nested paren) with a parenthesised term AFTER it
+  m1 <- glm(y ~ x + offset(log(off)) + factor(g), data = d, family = "poisson")
   # equivalent model with the offset supplied via the `offset` argument
-  m2 <- glm(y ~ x + g, offset = log(off), data = d, family = "poisson")
+  m2 <- glm(y ~ x + factor(g), offset = log(off), data = d, family = "poisson")
 
   nm1 <- null_model(m1)
   nm2 <- null_model(m2)

--- a/tests/testthat/test-null_model.R
+++ b/tests/testthat/test-null_model.R
@@ -2,7 +2,7 @@ skip_if_not_installed("glmmTMB")
 skip_if_not_installed("lme4")
 skip_if_not_installed("TMB")
 
-test_that("null_model with offset", {
+test_that("null_model with offset-1", {
   data(mtcars)
   m1 <- suppressWarnings(lme4::glmer.nb(
     mpg ~ disp + (1 | cyl) + offset(log(wt)),
@@ -20,7 +20,7 @@ test_that("null_model with offset", {
 
 skip_on_os("mac") # error: FreeADFunObject
 
-test_that("null_model with offset", {
+test_that("null_model with offset-2", {
   data(mtcars)
   m1 <- suppressWarnings(glmmTMB::glmmTMB(
     mpg ~ disp + (1 | cyl) + offset(log(wt)),
@@ -136,7 +136,7 @@ test_that("null_model with non-mixed glmmTMB", {
 })
 
 
-test_that("null_model with offset", {
+test_that("null_model with offset-3", {
   set.seed(123)
   N <- 100 # Samples
   x <- runif(N, 0, 10) # Predictor
@@ -150,9 +150,12 @@ test_that("null_model with offset", {
 
   m1 <- glm(y ~ x + offset(logOff), data = d, family = "poisson")
   m2 <- glm(y ~ x, offset = logOff, data = d, family = "poisson")
+  m3 <- glm(y ~ offset(logOff) + x, data = d, family = "poisson")
   nm1 <- null_model(m1)
   nm2 <- null_model(m2)
+  nm3 <- null_model(m3)
   expect_equal(coef(nm1), coef(nm2), tolerance = 1e-4)
+  expect_equal(coef(nm1), coef(nm3), tolerance = 1e-4)
 })
 
 


### PR DESCRIPTION
## Problem

`null_model()` errors for a model whose offset is written inline in the formula
as a **nested-parenthesis expression followed by further terms**:

```r
library(glmmTMB)
m <- glmmTMB(
  y ~ x + offset(log(exposure)) + factor(year),
  data = d, family = nbinom2()
)
insight::null_model(m)
#> Error in str2lang(offset_term) :
#>   <text>:1:19: unexpected ')'
#>   1: log(exposure))
```

This also breaks every downstream consumer that builds a null model, e.g.
`performance::r2_mcfadden()` / `r2_nagelkerke()` / `r2_coxsnell()` and therefore
`performance::model_performance()`.

## Cause

`.grep_offset_term()` extracted the offset from the *deparsed* formula with a
paren-blind regex:

```r
gsub("(.*)offset\\((.*)\\)(.*)", "\\2", f)
```

That assumes the closing paren of `offset(` is the last `)` in the string. When
the offset expression itself contains parentheses (`offset(log(exposure))`) and
other terms follow it, the offset's `)` is no longer the last one, so the regex
captures an unbalanced, unparseable substring
(`log(exposure)) + factor(year`), and `str2lang()` fails.

## Fix

Extract the offset by walking the formula's language tree for the `offset()`
call and deparsing its argument. This is correct regardless of nested
parentheses or term order, and leaves the previously-working cases unchanged.

## Tests

Added a regression test in `test-null_model.R` (inline nested-paren offset with
a trailing `factor()` term) asserting `null_model()` builds without error, keeps
the offset, and matches the equivalent model fit with the `offset =` argument.
`test-null_model.R` and `test-offset.R` pass.
