### PR TITLE
Extend modelbased support for new cogmod models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,12 @@
 
 ## Changes
 
+* `model_info()` and `get_predicted()` now recognize the `ddm()`, `lba()` and
+  `rdm()` custom *brms* families from package *cogmod* as reaction-time and
+  choice models (`is_rtchoice`), alongside the already supported `lnr()`. Their
+  predictions are hence split into the `"rt"` and `"response"` components,
+  instead of being returned as a single interleaved vector.
+
 * `get_datagrid()` gains a `weighted` argument, to create a smaller representation
   of large data grids, where multiple unique combinations of predictors are
   included only once, and a new `Weight` column indicates how often each

--- a/R/get_predicted_bayesian.R
+++ b/R/get_predicted_bayesian.R
@@ -86,7 +86,7 @@ get_predicted.stanreg <- function(
   is_wiener <- inherits(model_family, "brmsfamily") && model_family$family == "wiener"
   is_rtchoice <- inherits(model_family, "brmsfamily") &&
     model_family$family == "custom" &&
-    model_family$name == "lnr"
+    .is_rtchoice_family(model_family$name)
   is_mixture <- inherits(model_family, "brmsfamily") && model_family$family == "mixture"
 
   # Special case for rwiener (get choice 1 as negative values)
@@ -123,7 +123,8 @@ get_predicted.stanreg <- function(
     } else if (is_rtchoice) {
       # Reaction time and Choice Models --------------------
       # ----------------------------------------------------
-      # LogNormal Race models (cogmod package) return RT and Choice as odd and even columns
+      # DDM, LBA, LogNormal Race and RDM models (cogmod package) return RT and
+      # Choice as odd and even columns
       response <- as.matrix(draws[, seq(2, ncol(draws), 2)])
       draws <- as.matrix(draws[, seq(1, ncol(draws), 2)])
       draws <- array(

--- a/R/model_info.R
+++ b/R/model_info.R
@@ -57,7 +57,8 @@
 #' * `is_hurdle`: model has zero-inflation component and is a hurdle-model (truncated family distribution)
 #' * `is_rtchoice`: model is a *brms* decision-making (sequential sampling) model,
 #'   which models outcomes that consists of two components (reaction times and
-#'   choice).
+#'   choice). This currently covers the `ddm()`, `lba()`, `lnr()` and `rdm()`
+#'   custom families from package *cogmod*.
 #' * `is_survival`: model is a survival model
 #' * `is_trial`: model response contains additional information about the trials
 #' * `is_truncated`: model is a truncated model (has a truncated response)

--- a/R/utils_model_info.R
+++ b/R/utils_model_info.R
@@ -472,7 +472,7 @@
     is_wiener = inherits(x, "brmsfit") && fitfam == "wiener",
     is_rtchoice = inherits(x, "brmsfit") &&
       fitfam == "custom" &&
-      identical(brms_custom_name, "lnr"),
+      .is_rtchoice_family(brms_custom_name),
     is_mixture = fitfam == "mixture",
     link_function = link.fun,
     family = fitfam,
@@ -545,4 +545,13 @@
 
 .is_semLme <- function(x) {
   all(inherits(x, c("sem", "lme")))
+}
+
+
+# Custom brms families (from the *cogmod* package) that jointly model reaction
+# times and choice, and whose `posterior_predict()` methods return both
+# components: reaction times in the odd and choices in the even columns.
+.is_rtchoice_family <- function(family_name) {
+  !is.null(family_name) &&
+    family_name %in% c("ddm", "lba", "lnr", "rdm")
 }

--- a/man/model_info.Rd
+++ b/man/model_info.Rd
@@ -75,7 +75,8 @@ works for \emph{brmsfit} and \emph{vglm/vgam} objects)
 \item \code{is_hurdle}: model has zero-inflation component and is a hurdle-model (truncated family distribution)
 \item \code{is_rtchoice}: model is a \emph{brms} decision-making (sequential sampling) model,
 which models outcomes that consists of two components (reaction times and
-choice).
+choice). This currently covers the \code{ddm()}, \code{lba()}, \code{lnr()} and \code{rdm()}
+custom families from package \emph{cogmod}.
 \item \code{is_survival}: model is a survival model
 \item \code{is_trial}: model response contains additional information about the trials
 \item \code{is_truncated}: model is a truncated model (has a truncated response)


### PR DESCRIPTION
The `is_rtchoice ` enables special processing to deal with the otherwise interleaved predictions made in brms, this simply adds the new models to the list