### PR TITLE
`get_df()` gains `df_per_obs` support for `mmrm`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.5.2.11
+Version: 1.5.2.12
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,10 @@
 
 ## Changes
 
+* `get_df()` now supports the `df_per_obs` argument for models of class `mmrm`,
+  returning one degree of freedom per row of `data` instead of one per
+  coefficient, using the method chosen when fitting the model.
+
 * `model_info()` and `get_predicted()` now recognize the `ddm()`, `lba()` and
   `rdm()` custom *brms* families from package *cogmod* as reaction-time and
   choice models (`is_rtchoice`), alongside the already supported `lnr()`. Their

--- a/R/get_df.R
+++ b/R/get_df.R
@@ -285,7 +285,15 @@ get_df.svy2lme <- function(x, type = "residual", verbose = TRUE, ...) {
 
 #' @export
 get_df.mmrm <- function(x, type = "residual", verbose = TRUE, ...) {
-  if (identical(type, "model")) {
+  # hidden gem - required when per-observation DF are needed, e.g. to compute
+  # confidence intervals around predictions. note that "mmrm" models have no
+  # `type` option: the method used to compute the degrees of freedom is chosen
+  # when the model is fitted, and is used for all contrasts
+  dots <- list(...)
+
+  if (isTRUE(dots$df_per_obs)) {
+    .mmrm_df_per_obs(x, dots$data)
+  } else if (identical(type, "model")) {
     .model_df(x)
   } else {
     summary_table <- stats::coef(summary(x))

--- a/R/get_predicted_ci.R
+++ b/R/get_predicted_ci.R
@@ -359,6 +359,25 @@ get_predicted_ci.bracl <- get_predicted_ci.mlm
 }
 
 
+.mmrm_df_per_obs <- function(x, data = NULL) {
+  check_if_installed("mmrm")
+  if (is.null(data)) {
+    data <- get_data(x, verbose = FALSE)
+  }
+  if (!inherits(data, "data.frame")) {
+    format_error("The `data` argument should be a data frame.")
+  }
+  mm <- get_modelmatrix(x, data = data)
+  # `df_1d()` uses the method that was chosen when fitting the model, e.g.
+  # Satterthwaite or Kenward-Roger
+  vapply(
+    seq_len(nrow(mm)),
+    function(i) mmrm::df_1d(x, mm[i, ])$df,
+    numeric(1)
+  )
+}
+
+
 .get_predicted_se_to_ci_zeroinfl <- function(
   x,
   predictions = NULL,

--- a/tests/testthat/test-mmrm.R
+++ b/tests/testthat/test-mmrm.R
@@ -48,6 +48,48 @@ test_that("get_df", {
   expect_equal(get_df(mod_mmrm, type = "model"), 12, ignore_attr = TRUE)
 })
 
+test_that("get_df, per observation", {
+  d <- get_data(mod_mmrm)
+  out1 <- get_df(mod_mmrm, type = "satterthwaite", df_per_obs = TRUE, data = d)
+  out2 <- get_df(mod_mmrm, type = "satterthwaite", df_per_obs = FALSE)
+  expect_length(out1, nrow(d))
+  expect_length(out2, 11)
+  # `data` defaults to the data used to fit the model
+  expect_equal(
+    get_df(mod_mmrm, df_per_obs = TRUE),
+    out1,
+    ignore_attr = TRUE,
+    tolerance = 1e-4
+  )
+  # same Satterthwaite DF as `emmeans` for the same combination of predictors
+  skip_if_not_installed("emmeans")
+  emm <- emmeans::emmeans(
+    mod_mmrm,
+    ~ RACE + SEX + ARMCD + AVISIT,
+    at = lapply(d[1, c("RACE", "SEX", "ARMCD", "AVISIT")], as.character)
+  )
+  expect_equal(
+    out1[1],
+    summary(emm)$df,
+    ignore_attr = TRUE,
+    tolerance = 1e-4
+  )
+  # same for a model fitted with Kenward-Roger (which happens to give the same
+  # degrees of freedom as Satterthwaite for this balanced design)
+  mod_kr <- mmrm::mmrm(
+    formula = FEV1 ~ RACE + SEX + ARMCD * AVISIT + us(AVISIT | USUBJID),
+    data = fev_data,
+    method = "Kenward-Roger"
+  )
+  emm_kr <- emmeans::emmeans(
+    mod_kr,
+    ~ RACE + SEX + ARMCD + AVISIT,
+    at = lapply(d[1, c("RACE", "SEX", "ARMCD", "AVISIT")], as.character)
+  )
+  out_kr <- get_df(mod_kr, df_per_obs = TRUE)
+  expect_equal(out_kr[1], summary(emm_kr)$df, ignore_attr = TRUE, tolerance = 1e-4)
+})
+
 test_that("n_parameters", {
   expect_identical(n_parameters(mod_mmrm), 11L)
 })


### PR DESCRIPTION
`get_df.mmrm()` ignored `df_per_obs` and always returned one DF per coefficient, so callers that need per-observation DF — such as confidence intervals around predictions — got a length-`p` vector instead of length-`nrow(data)`. It now dispatches to `.mmrm_df_per_obs()`, which loops `mmrm::df_1d()` over the model matrix rows, mirroring `.satterthwaite_kr_df_per_obs()` for `lmerMod`.

Unlike `lmerMod`, the new branch does not condition on `type`: `mmrm` fixes the DF method when the model is fitted, so `type` cannot select between Satterthwaite and Kenward-Roger. Validated against `emmeans`.
