### PR TITLE
docs: fix typo occurence -> occurrence

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -76,7 +76,7 @@ Values estimated or learned from data that capture the relationship between vari
 
 #### Variables
 
-Any unique variable names that appear in a regression model, e.g., response variable, predictors or random effects. A "variable" only relates to the unique occurence of a term, or the term name. For instance, the expression `x + poly(x, 2)` has only the variable `x`.
+Any unique variable names that appear in a regression model, e.g., response variable, predictors or random effects. A "variable" only relates to the unique occurrence of a term, or the term name. For instance, the expression `x + poly(x, 2)` has only the variable `x`.
 
 #### Terms
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ as *coefficients*.
 
 Any unique variable names that appear in a regression model, e.g.,
 response variable, predictors or random effects. A “variable” only
-relates to the unique occurence of a term, or the term name. For
+relates to the unique occurrence of a term, or the term name. For
 instance, the expression `x + poly(x, 2)` has only the variable `x`.
 
 #### Terms

--- a/paper/paper.md
+++ b/paper/paper.md
@@ -69,7 +69,7 @@ Values estimated or learned from data that capture the relationship between vari
 
 ### Variables
 
-Any unique variable names that appear in a regression model, e.g., response variable, predictors or random effects. A "variable" only relates to the unique occurence of a term, or the term name. For instance, the expression `x + poly(x, 2)` has only the variable `x`.
+Any unique variable names that appear in a regression model, e.g., response variable, predictors or random effects. A "variable" only relates to the unique occurrence of a term, or the term name. For instance, the expression `x + poly(x, 2)` has only the variable `x`.
 
 ![Definition of Model Components: Variables](figure3b.png)
 


### PR DESCRIPTION
Typo fix: `occurence` → `occurrence`, in the definition of "variable".

- `README.Rmd:79` — the source
- `README.md:106` — the knitted output
- `paper/paper.md:72` — same sentence in the JOSS paper

I initially only touched `README.md`; including `README.Rmd` too means the fix survives the next `knit` instead of being regenerated away.