### PR TITLE
Don't match auxiliary parameter names fuzzily

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: insight
 Title: Easy Access to Model Information for Various Model Objects
-Version: 1.5.4
+Version: 1.5.4.1
 Authors@R:
     c(person(given = "Daniel",
              family = "Lüdecke",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# insight (devel)
+
+## Bug fixes
+
+* `find_auxiliary()` no longer returns `"sigma"` for *brms* models that have no
+  residual standard deviation, but auxiliary parameters whose names merely
+  contain `"sigma"` (e.g. `"sigmadrift"` or `"sigmabias"` from custom families).
+
+* `clean_parameters()` no longer assigns auxiliary parameters whose names
+  contain `"sigma"` (like `"sigmabias"`) to the `"sigma"` component. These are
+  now returned as their own component, which also fixes the related grouping in
+  `parameters::model_parameters()`.
+
 # insight 1.5.4
 
 ## Bug fixes

--- a/R/clean_parameters.R
+++ b/R/clean_parameters.R
@@ -411,24 +411,21 @@ clean_parameters.mlm <- function(x, ...) {
       "fixed"
     }
 
-    # we must start with "conditional one", so it's not confused with "conditional"
-    com <- if (grepl("conditional", i, fixed = TRUE) || i == "random") {
-      "conditional"
-    } else if (grepl("sigma", i, fixed = TRUE)) {
-      "sigma"
-    } else if (grepl("priors", i, fixed = TRUE)) {
-      "priors"
-    } else if (i %in% c("car", "sdcar")) {
-      "car"
-    } else if (grepl("smooth_terms", i, fixed = TRUE)) {
-      "smooth_terms"
-    } else if (grepl("dispersion", i, fixed = TRUE)) {
-      "dispersion"
-    } else if (endsWith(i, "_random")) {
-      gsub("_random$", "", i)
-    } else {
-      i
-    }
+    # elements that hold the group-level part of a component have a "_random"
+    # suffix, e.g. "sigma_random" belongs to the component "sigma" - we strip
+    # that suffix, and then compare the resulting name against the known
+    # components. Note that we must check for *exact* matches here, else
+    # auxiliary parameters of custom brms-families, like "sigmabias", would be
+    # lumped together with the "sigma" component (see #1224)
+    com <- sub("_random$", "", i)
+    com <- switch(
+      com,
+      conditional = ,
+      random = "conditional",
+      car = ,
+      sdcar = "car",
+      com
+    )
 
     fun <- if (grepl("smooth", i, fixed = TRUE)) {
       "smooth"

--- a/R/find_auxiliary.R
+++ b/R/find_auxiliary.R
@@ -39,10 +39,34 @@ find_auxiliary.brmsfit <- function(x, ...) {
   } else {
     out <- names(f$pforms)
   }
-  # add sigma
-  fe <- dimnames(x$fit)$parameters
-  if (any(startsWith(fe, "sigma_") | grepl("sigma", fe, fixed = TRUE))) {
+  # "pforms" only contains those distributional parameters that were modelled
+  # with a formula. "sigma" usually is estimated as a single (constant)
+  # parameter, and thus is missing from "pforms" - we then have to look at the
+  # parameter names of the related stan-model. Note that we must check for
+  # *exact* matches here, else auxiliary parameters of custom families, like
+  # "sigmabias" or "sigmadrift", would be mistaken for "sigma" (see #1224).
+  if (!"sigma" %in% out && .brms_has_sigma(x)) {
     out <- c(out, "sigma")
   }
   unique(out)
+}
+
+
+# checks whether a brms-model has an estimated residual standard deviation
+# ("sigma") that was *not* modelled as a distributional parameter (i.e. that
+# has no formula, and hence does not appear in the model's "pforms")
+.brms_has_sigma <- function(x) {
+  fe <- dimnames(x$fit)$parameters
+  # "sigma" for univariate models, "sigma1", "sigma2" etc. for mixture models
+  if ("sigma" %in% fe || any(grepl("^sigma[0-9]+$", fe))) {
+    return(TRUE)
+  }
+  # multivariate models have one sigma per response, named "sigma_<response>"
+  if (!any(startsWith(fe, "sigma_"))) {
+    return(FALSE)
+  }
+  # brms uses "cleaned" response names for those (e.g. "SepalLength" instead
+  # of "Sepal.Length"), which are stored in the names of the response-vector
+  resp <- find_response(x, combine = FALSE)
+  any(fe %in% paste0("sigma_", c(resp, names(resp))))
 }

--- a/tests/testthat/test-brms_dpars.R
+++ b/tests/testthat/test-brms_dpars.R
@@ -1,0 +1,177 @@
+skip_if_not_installed("brms")
+
+# Minimal "brmsfit"-mockups, to test the detection of auxiliary (distributional)
+# parameters without the need of fitting (or downloading) a model.
+# `find_auxiliary()` and `clean_parameters()` only require the model's formula
+# and the parameter names of the related stan-model.
+.brmsfit_mock <- function(formula, parameters) {
+  fit <- array(
+    0,
+    dim = c(1, 1, length(parameters)),
+    dimnames = list(iterations = NULL, chains = NULL, parameters = parameters)
+  )
+  structure(list(formula = formula, fit = fit, family = NULL), class = "brmsfit")
+}
+
+
+test_that("find_auxiliary, sigma estimated as constant parameter", {
+  m <- .brmsfit_mock(
+    brms::bf(mpg ~ hp),
+    c("b_Intercept", "b_hp", "sigma", "Intercept", "lprior", "lp__")
+  )
+  expect_identical(find_auxiliary(m), "sigma")
+})
+
+
+test_that("find_auxiliary, sigma modelled as distributional parameter", {
+  m <- .brmsfit_mock(
+    brms::bf(mpg ~ hp, sigma ~ cyl),
+    c("b_Intercept", "b_hp", "b_sigma_Intercept", "b_sigma_cyl", "Intercept_sigma")
+  )
+  expect_identical(find_auxiliary(m), "sigma")
+})
+
+
+test_that("find_auxiliary, sigma in multivariate models", {
+  m <- .brmsfit_mock(
+    brms::bf(Sepal.Length ~ Petal.Length) + brms::bf(Sepal.Width ~ Species),
+    c(
+      "b_SepalLength_Intercept", "b_SepalLength_Petal.Length",
+      "b_SepalWidth_Intercept", "b_SepalWidth_Speciesversicolor",
+      "sigma_SepalLength", "sigma_SepalWidth"
+    )
+  )
+  expect_identical(find_auxiliary(m), "sigma")
+})
+
+
+test_that("find_auxiliary, sigma in mixture models", {
+  m <- .brmsfit_mock(
+    brms::bf(mpg ~ hp),
+    c("b_mu1_Intercept", "b_mu2_Intercept", "sigma1", "sigma2", "theta1", "theta2")
+  )
+  expect_identical(find_auxiliary(m), "sigma")
+})
+
+
+test_that("find_auxiliary, no sigma for models without residual SD", {
+  m <- .brmsfit_mock(
+    brms::bf(count ~ Trt),
+    c("b_Intercept", "b_Trt1", "Intercept", "lprior", "lp__")
+  )
+  expect_null(find_auxiliary(m))
+})
+
+
+test_that("find_auxiliary does not mistake custom dpars for sigma, #1224", {
+  # custom families may have auxiliary parameters that only *contain* the
+  # word "sigma" - these must not be detected as "sigma"
+  m <- .brmsfit_mock(
+    brms::bf(rt ~ Condition, boundary ~ Condition, bias ~ 1, ndt ~ 1),
+    c(
+      "b_Intercept", "b_boundary_Intercept", "b_bias_Intercept",
+      "b_ndt_Intercept", "sigmadrift", "sigmabias", "sigmandt", "poutlier"
+    )
+  )
+  expect_identical(find_auxiliary(m), c("boundary", "bias", "ndt"))
+
+  # "sigmabias" is modelled, but there still is no "sigma" in the model
+  m <- .brmsfit_mock(
+    brms::bf(rt ~ Condition, sigmabias ~ Condition, boundary ~ 1, ndt ~ 1),
+    c(
+      "b_Intercept", "b_sigmabias_Intercept", "b_boundary_Intercept",
+      "b_ndt_Intercept", "sigmadrift", "poutlier"
+    )
+  )
+  expect_identical(find_auxiliary(m), c("sigmabias", "boundary", "ndt"))
+})
+
+
+test_that("find_auxiliary, default method", {
+  expect_warning(
+    find_auxiliary(lm(mpg ~ hp, data = mtcars)),
+    regex = "only works for"
+  )
+  expect_null(find_auxiliary(lm(mpg ~ hp, data = mtcars), verbose = FALSE))
+})
+
+
+test_that("clean_parameters does not lump custom dpars into sigma, #1224", {
+  # "sigmabias" is a distributional parameter of its own, and must not be
+  # assigned to the "sigma" component, although the model *does* have a sigma
+  m <- .brmsfit_mock(
+    brms::bf(rt ~ Condition, sigmabias ~ Condition, boundary ~ Condition, ndt ~ 1),
+    c(
+      "b_Intercept", "b_ConditionSpeed",
+      "b_sigmabias_Intercept", "b_sigmabias_ConditionSpeed",
+      "b_boundary_Intercept", "b_boundary_ConditionSpeed",
+      "b_ndt_Intercept", "sigma"
+    )
+  )
+  out <- clean_parameters(m)
+  expect_identical(
+    out$Component,
+    c(
+      "conditional", "conditional", "ndt", "sigma", "sigmabias", "sigmabias",
+      "boundary", "boundary"
+    )
+  )
+  expect_identical(
+    out$Cleaned_Parameter,
+    c(
+      "(Intercept)", "ConditionSpeed", "(Intercept)", "sigma", "(Intercept)",
+      "ConditionSpeed", "(Intercept)", "ConditionSpeed"
+    )
+  )
+})
+
+
+test_that("clean_parameters keeps sigma and its random effects together", {
+  m <- .brmsfit_mock(
+    brms::bf(y ~ x, sigma ~ x + (1 | id)),
+    c(
+      "b_Intercept", "b_x", "b_sigma_Intercept", "b_sigma_x",
+      "sd_id__sigma_Intercept", "r_id__sigma[1,Intercept]"
+    )
+  )
+  out <- clean_parameters(m)
+  expect_identical(
+    out$Component,
+    c("conditional", "conditional", "sigma", "sigma", "sigma", "sigma")
+  )
+  expect_identical(
+    out$Effects,
+    c("fixed", "fixed", "fixed", "fixed", "random", "random")
+  )
+})
+
+
+test_that(".get_stan_params maps component names for all supported classes", {
+  # element names that `find_parameters()` returns for the model classes that
+  # share this helper (brmsfit, stanreg, stanfit, stanmvreg and bamlss), plus
+  # their group-level ("_random") counterparts
+  elements <- c(
+    "conditional", "random", "conditional_random", "sigma", "sigma_random",
+    "smooth_terms", "smooth_terms_random", "auxiliary", "alpha", "priors",
+    "dispersion", "dispersion_random", "zi", "zi_random", "car", "sdcar",
+    # auxiliary parameters of custom families that merely *contain* the name
+    # of a known component
+    "sigmabias", "sigmabias_random", "sigmadrift"
+  )
+  pars <- stats::setNames(as.list(elements), elements)
+  out <- do.call(rbind, insight:::.get_stan_params(pars))
+
+  expect_identical(
+    out$Component,
+    c(
+      "conditional", "conditional", "conditional", "sigma", "sigma",
+      "smooth_terms", "smooth_terms", "auxiliary", "alpha", "priors",
+      "dispersion", "dispersion", "zi", "zi", "car", "car",
+      "sigmabias", "sigmabias", "sigmadrift"
+    )
+  )
+  expect_identical(
+    out$Effects[endsWith(elements, "_random") | elements == "random"],
+    rep("random", 7)
+  )
+})

--- a/tests/testthat/test-get_predicted.R
+++ b/tests/testthat/test-get_predicted.R
@@ -890,6 +890,7 @@ test_that("zero-inflation stuff works", {
 
 
 test_that("get_predicted works with brms-Wiener (cogmod-RT-choice)", {
+  skip_if_not_installed("cogmod")
   skip_if_not_installed("brms")
   skip_if_not_installed("RWiener")
   skip_if_not_installed("curl")


### PR DESCRIPTION
Fixes #1224, and the related component grouping in easystats/parameters#1247.

## `find_auxiliary()` hallucinated `sigma`

The residual SD was detected by looking for the string `"sigma"` *anywhere* in the stan-model's parameter names:

```r
if (any(startsWith(fe, "sigma_") | grepl("sigma", fe, fixed = TRUE))) {
  out <- c(out, "sigma")
}
```

Custom brms-families whose auxiliary parameters merely *contain* that string therefore faked a `sigma` component. The `ddm()` family from *cogmod* estimates `sigmadrift`, `sigmabias` and `sigmandt` as constants, so:

```r
m <- readRDS(url("https://raw.github.com/DominiqueMakowski/cogmod/main/vignettes/models/m_ddm.rds"))
insight::find_auxiliary(m)
#> before: "boundary" "bias" "ndt" "sigma"
#> after:  "boundary" "bias" "ndt"
```

`sigma` is now matched exactly, and only when it isn't already covered by the model's `pforms`:

- `sigma` — univariate models with a constant residual SD
- `sigma_<response>` — multivariate models, validated against the actual response names (both the raw and brms' "cleaned" ones, e.g. `sigma_SepalLength` for `Sepal.Length`)
- `sigma1`, `sigma2`, … — mixture models

## `clean_parameters()` lumped `sigmabias` into `sigma`

Same root cause, different code path. `.get_stan_params()` mapped `find_parameters()` element names to components with a substring test, so the element *named* `sigmabias` matched `grepl("sigma", ...)` and its parameters were labelled `Component = "sigma"` — even though `find_parameters()` had correctly returned `sigma` and `sigmabias` as separate elements. That is what surfaces as easystats/parameters#1247; `parameters` itself needed no change, its output is downstream of `clean_parameters()`.

Component names are now compared for exact matches, after stripping the `_random` suffix that marks the group-level part of a component. The `grepl` branches for `conditional`, `priors`, `smooth_terms` and `dispersion` become redundant once that suffix is stripped, since they fall through to the identity default — so they are gone too, which removes the same fuzziness for those.

```r
m_lba <- readRDS(url("https://raw.github.com/DominiqueMakowski/cogmod/main/vignettes/models/m_lba1.rds"))
parameters::parameters(m_lba)
#> before: b_sigmabias_Intercept -> Component = sigma
#> after:  b_sigmabias_Intercept -> Component = sigmabias
```

Note this model genuinely has an exact `sigma` parameter (fixed to 1), so the `find_auxiliary()` fix alone did not address it; it still shows up as its own `sigma` component, correctly.

## Verification

- Old vs. new `find_auxiliary()` output compared across 19 downloadable brms models (univariate, mv with dotted response names, mixture, zi, zoib, ordinal, distributional `sigma ~ x`, `sigma` with random effects, custom `chocomini` family) — **identical in every case**.
- New `tests/testthat/test-brms_dpars.R` covers both bugs with lightweight `brmsfit` mockups (formula + stan parameter names), so no fitting or downloading is needed; the mockups reproduce the real models' output exactly. It also unit-tests the `.get_stan_params()` component mapping over the element names produced by all five classes that share the helper — `brmsfit`, `stanreg`, `stanfit`, `stanmvreg`, `bamlss` — since *rstanarm* isn't available locally to exercise those paths end-to-end.
- Full local test suite: no new failures. The three that remain (two lavaan `GFI` values in `test-export_table.R`, and `rt`/`RT` in `test-get_predicted.R:904`) reproduce unchanged on `main`.
- `parameters`' own `brms|stan|bayes` tests pass against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
